### PR TITLE
Refactored Kubernetes external services to use NGINX Ingress controller

### DIFF
--- a/deployment.yml
+++ b/deployment.yml
@@ -56,8 +56,39 @@ metadata:
 spec:
   selector:
     app: spotifind-app
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - protocol: TCP
       port: 8080
       targetPort: 5000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-load-balancer
+  namespace: spotifind
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx-class
+  rules:
+  - http:
+      paths:
+      - path: /index
+        pathType: Prefix
+        backend:
+          service:
+            name: spotifind-service
+            port:
+              number: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+  name: nginx-class
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+spec:
+  controller: k8s.io/ingress-nginx


### PR DESCRIPTION
## Related Issue
- #19 
<!-- Related issues go here -->

## Description
- All existing external services interfacing with our Kubernetes cluster for our web service are of type [LoadBalancer](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer). Each service of this type creates a LoadBalancer accessible by an external IP. Consequently, we have that each individual Kubernetes service is managed by an external LoadBalancer. This pull request is created in order to refactor all LoadBalancer services to instead use an [NGINX Ingress controller](https://kubernetes.github.io/ingress-nginx/) for edge routing in our cluster.
  - To verify these changes, I smoke tested using [minikube](https://minikube.sigs.k8s.io/docs/start/). By following the [installation guide](https://kubernetes.github.io/ingress-nginx/deploy/#gce-gke) for NGINX Ingress controllers, we were able to verify that our internal service is reachable from `{{externalIP}}/index`, where `externalIP` is the IP address exposed by our Ingress controller.

## Tests Included
- [ ] Unit tests
- [ ]  Integration tests
- [X] Environment tests
- [ ] Regression tests
- [X] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
