### PR TITLE
Exploratory programming gcloud notebook for ANN index deployment

### DIFF
--- a/notebooks/ann_endpoint_integration_notebook.ipynb
+++ b/notebooks/ann_endpoint_integration_notebook.ipynb
@@ -1,0 +1,559 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "8f978f57-4d57-4b94-b7b6-40d2638ca630",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import match_service_pb2\n",
+    "import match_service_pb2_grpc\n",
+    "import grpc\n",
+    "\n",
+    "from google.cloud import aiplatform_v1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "89261541-a9cf-45ac-8787-ee959110a359",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "REGION = \"us-west1\"\n",
+    "PEERING_RANGE_NAME = \"spotifind-vpc-peering-range2\"\n",
+    "location = \"projects/841506577075/locations/{}\".format(REGION)\n",
+    "aiplatform_endpoint = \"{}-aiplatform.googleapis.com\".format(REGION)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "73103eda-2618-49a8-9324-a71af79ee623",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# (IndexEndpointService) get ANN index endpoint for current region (~us-west1c/us-central1a)\n",
+    "index_endpoint_service_client = aiplatform_v1.IndexEndpointServiceClient(client_options=dict(api_endpoint=aiplatform_endpoint))\n",
+    "\n",
+    "list_index_endpoints_request = aiplatform_v1.ListIndexEndpointsRequest(parent=location)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4944ec8f-3f8c-4ceb-a629-585b3302f1e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pager_result = index_endpoint_service_client.list_index_endpoints(request=list_index_endpoints_request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "949b2669-7959-4187-ba7f-1404abc5f1a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "name: \"projects/841506577075/locations/us-west1/indexEndpoints/5298379408485122048\"\n",
+       "display_name: \"index_endpoint_for_spotifind_demo2\"\n",
+       "deployed_indexes {\n",
+       "  id: \"spotifind_ann_index-deployed\"\n",
+       "  index: \"projects/841506577075/locations/us-west1/indexes/8335635144681455616\"\n",
+       "  display_name: \"spotifind_ann_index-deployed\"\n",
+       "  create_time {\n",
+       "    seconds: 1655663657\n",
+       "    nanos: 887493000\n",
+       "  }\n",
+       "  private_endpoints {\n",
+       "    match_grpc_address: \"172.24.2.5\"\n",
+       "  }\n",
+       "  index_sync_time {\n",
+       "    seconds: 1655683243\n",
+       "    nanos: 368194000\n",
+       "  }\n",
+       "  automatic_resources {\n",
+       "    min_replica_count: 2\n",
+       "    max_replica_count: 2\n",
+       "  }\n",
+       "  reserved_ip_ranges: \"spotifind-vpc-peering-range2\"\n",
+       "  deployment_group: \"default\"\n",
+       "}\n",
+       "etag: \"AMEw9yP0Tk_dRxLfyDtoaXjCp5HJeOQ7Y603CKbtNQQtWqLKjyP5RxL4xj-T_t9Rq_0M\"\n",
+       "create_time {\n",
+       "  seconds: 1653951391\n",
+       "  nanos: 773162000\n",
+       "}\n",
+       "update_time {\n",
+       "  seconds: 1653951392\n",
+       "  nanos: 414257000\n",
+       "}\n",
+       "network: \"projects/841506577075/global/networks/spotifind-vpc2\""
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spotifind_index_endpoint = pager_result.index_endpoints[0]\n",
+    "spotifind_index_endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f4882145-573e-4b49-a185-bd3554ef18c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# (IndexService) get ANN index for current region (~us-west1c/us-central1a)\n",
+    "index_service_client = aiplatform_v1.IndexServiceClient(client_options=dict(api_endpoint=aiplatform_endpoint))\n",
+    "\n",
+    "list_indexes_request = aiplatform_v1.ListIndexesRequest(parent=location)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "0dbf2c83-f8c8-4e69-b1a3-c18042528600",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "indexes_pager_result = index_service_client.list_indexes(request=list_indexes_request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "85d5894c-c3d5-4ec7-9c56-b02d401ac644",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "name: \"projects/841506577075/locations/us-west1/indexes/8335635144681455616\"\n",
+       "display_name: \"spotifind_ann_index\"\n",
+       "description: \"Spotifind ANN index\"\n",
+       "metadata_schema_uri: \"gs://google-cloud-aiplatform/schema/matchingengine/metadata/nearest_neighbor_search_1.0.0.yaml\"\n",
+       "metadata {\n",
+       "  struct_value {\n",
+       "    fields {\n",
+       "      key: \"config\"\n",
+       "      value {\n",
+       "        struct_value {\n",
+       "          fields {\n",
+       "            key: \"algorithmConfig\"\n",
+       "            value {\n",
+       "              struct_value {\n",
+       "                fields {\n",
+       "                  key: \"treeAhConfig\"\n",
+       "                  value {\n",
+       "                    struct_value {\n",
+       "                      fields {\n",
+       "                        key: \"leafNodeEmbeddingCount\"\n",
+       "                        value {\n",
+       "                          string_value: \"500\"\n",
+       "                        }\n",
+       "                      }\n",
+       "                      fields {\n",
+       "                        key: \"leafNodesToSearchPercent\"\n",
+       "                        value {\n",
+       "                          number_value: 7.0\n",
+       "                        }\n",
+       "                      }\n",
+       "                    }\n",
+       "                  }\n",
+       "                }\n",
+       "              }\n",
+       "            }\n",
+       "          }\n",
+       "          fields {\n",
+       "            key: \"approximateNeighborsCount\"\n",
+       "            value {\n",
+       "              number_value: 150.0\n",
+       "            }\n",
+       "          }\n",
+       "          fields {\n",
+       "            key: \"dimensions\"\n",
+       "            value {\n",
+       "              number_value: 11.0\n",
+       "            }\n",
+       "          }\n",
+       "          fields {\n",
+       "            key: \"distanceMeasureType\"\n",
+       "            value {\n",
+       "              string_value: \"DOT_PRODUCT_DISTANCE\"\n",
+       "            }\n",
+       "          }\n",
+       "        }\n",
+       "      }\n",
+       "    }\n",
+       "  }\n",
+       "}\n",
+       "deployed_indexes {\n",
+       "  index_endpoint: \"projects/841506577075/locations/us-west1/indexEndpoints/5298379408485122048\"\n",
+       "  deployed_index_id: \"spotifind_ann_index-deployed\"\n",
+       "}\n",
+       "etag: \"AMEw9yMho05QKHCHxwgD-_24ogVkBEvDfFU-V89pF-jsVkjSk29j-2eYjKGsiftvHRZA\"\n",
+       "create_time {\n",
+       "  seconds: 1653949326\n",
+       "  nanos: 713497000\n",
+       "}\n",
+       "update_time {\n",
+       "  seconds: 1653951178\n",
+       "  nanos: 544841000\n",
+       "}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spotifind_index = indexes_pager_result.indexes[0]\n",
+    "spotifind_index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "e49881da-bb7c-4813-a6ce-81e94685ccb8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get deployed index from index\n",
+    "\n",
+    "def deploy_index(index, index_endpoint, client):\n",
+    "    deployed_index = aiplatform_v1.DeployedIndex({\n",
+    "        \"id\": \"{}-deployed\".format(index.display_name),\n",
+    "        \"index\": index.name,\n",
+    "        \"display_name\": \"{}-deployed\".format(index.display_name),\n",
+    "        \"reserved_ip_ranges\": [\n",
+    "            PEERING_RANGE_NAME\n",
+    "        ]\n",
+    "    })\n",
+    "    \n",
+    "    deployed_index_request = aiplatform_v1.DeployIndexRequest(index_endpoint=index_endpoint.name, deployed_index=deployed_index)\n",
+    "    \n",
+    "    return client.deploy_index(request=deployed_index_request)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "862b081e-f603-4c43-9a2f-73dc5bfa6d4c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'projects/841506577075/locations/us-west1/indexes/8335635144681455616'"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spotifind_index.name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "cec71120-644c-409e-943b-617d3f2ffe8f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'projects/841506577075/locations/us-west1/indexEndpoints/5298379408485122048'"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spotifind_index_endpoint.name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "54efbca3-407b-49d4-bcd3-ba5362c6c846",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "deployed_indexes = spotifind_index.deployed_indexes\n",
+    "\n",
+    "deployed_index = None\n",
+    "if not deployed_indexes:\n",
+    "    deployed_index = deploy_index(spotifind_index, spotifind_index_endpoint, index_endpoint_service_client)\n",
+    "    print(deployed_index)\n",
+    "else:\n",
+    "    deployed_index = spotifind_index.deployed_indexes[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "0f262e71-59be-4f73-84d8-2e0a18f6555b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pager_result = index_endpoint_service_client.list_index_endpoints(request=list_index_endpoints_request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "28073660-c010-4761-85be-bcf8295db718",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[id: \"spotifind_ann_index-deployed\"\n",
+       "index: \"projects/841506577075/locations/us-west1/indexes/8335635144681455616\"\n",
+       "display_name: \"spotifind_ann_index-deployed\"\n",
+       "create_time {\n",
+       "  seconds: 1655663657\n",
+       "  nanos: 887493000\n",
+       "}\n",
+       "private_endpoints {\n",
+       "  match_grpc_address: \"172.24.2.5\"\n",
+       "}\n",
+       "index_sync_time {\n",
+       "  seconds: 1655683243\n",
+       "  nanos: 368194000\n",
+       "}\n",
+       "automatic_resources {\n",
+       "  min_replica_count: 2\n",
+       "  max_replica_count: 2\n",
+       "}\n",
+       "reserved_ip_ranges: \"spotifind-vpc-peering-range2\"\n",
+       "deployment_group: \"default\"\n",
+       "]"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pager_result.index_endpoints[0].deployed_indexes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "2c085614-601a-46d3-b9a9-50659b25ed95",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get gRPC address from private index endpoint for client calls\n",
+    "get_grpc_address = lambda deployed_index: deployed_index.private_endpoints.match_grpc_address\n",
+    "deployed_index = spotifind_index_endpoint.deployed_indexes[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6a26795-e9b1-4b37-b5fd-5d6974def3b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Match service wrapper init\n",
+    "# 1. (IndexEndpointService) get ANN index endpoint for current region (~us-west1c/us-central1a)\n",
+    "#   https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.services.index_endpoint_service.IndexEndpointServiceClient#google_cloud_aiplatform_v1_services_index_endpoint_service_IndexEndpointServiceClient_list_index_endpoints\n",
+    "# 2. Get deployed index from index endpoint\n",
+    "#   https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.types.DeployedIndex\n",
+    "# 3. If deployed index does not exist:\n",
+    "#   a. (IndexService) get ANN index for current region (~us-west1c/us-central1a)\n",
+    "#     https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.services.index_endpoint_service.IndexEndpointServiceClient#google_cloud_aiplatform_v1_services_index_endpoint_service_IndexEndpointServiceClient_list_index_endpoints\n",
+    "#   b. Deploy index from ANN index endpoint, ANN index, index endpoint service client\n",
+    "#     https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.services.index_endpoint_service.IndexEndpointServiceClient#google_cloud_aiplatform_v1_services_index_endpoint_service_IndexEndpointServiceClient_deploy_index\n",
+    "# 4. Get gRPC address from private index endpoint for client calls (https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.types.IndexPrivateEndpoints)\n",
+    "# https://github.com/googleapis/google-cloud-python\n",
+    "# https://github.com/googleapis/python-aiplatform"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "ada0d358-daa8-475a-b7a6-509b4c56930a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DEPLOYED_INDEX_SERVER_IP = get_grpc_address(deployed_index)\n",
+    "DEPLOYED_INDEX_ID = deployed_index.id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "6ebced8d-eb85-444a-9356-7faa8de9e4ab",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "172.24.2.5\n",
+      "spotifind_ann_index-deployed\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(DEPLOYED_INDEX_SERVER_IP)\n",
+    "print(DEPLOYED_INDEX_ID)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "48b7691e-2f90-4acb-ae85-d24bc51f9818",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "neighbor {\n",
+       "  id: \"2TRu7dMps7cVKOyazkj9Fb\"\n",
+       "  distance: -57.44913101196289\n",
+       "}\n",
+       "neighbor {\n",
+       "  id: \"0bqrFwY1HixfnusFxhYbDl\"\n",
+       "  distance: -60.509368896484375\n",
+       "}\n",
+       "neighbor {\n",
+       "  id: \"4BHSjbYylfOH5WAGusDyni\"\n",
+       "  distance: -64.6940689086914\n",
+       "}\n",
+       "neighbor {\n",
+       "  id: \"3s9f1LQ6607eDj9UYCzmgk\"\n",
+       "  distance: -65.47064971923828\n",
+       "}\n",
+       "neighbor {\n",
+       "  id: \"2HbKqm4o0w5wEeEFXm2sD4\"\n",
+       "  distance: -65.67963409423828\n",
+       "}\n",
+       "neighbor {\n",
+       "  id: \"53LkLW4k4w7EOayzvx70O9\"\n",
+       "  distance: -65.73475646972656\n",
+       "}\n",
+       "neighbor {\n",
+       "  id: \"6vy95NfrMeUfaXpaTm4O53\"\n",
+       "  distance: -67.0295181274414\n",
+       "}\n",
+       "neighbor {\n",
+       "  id: \"2VQc9orzwE6a5qFfy54P6e\"\n",
+       "  distance: -67.75544738769531\n",
+       "}\n",
+       "neighbor {\n",
+       "  id: \"6rladQVZPz1K5AgocaUgop\"\n",
+       "  distance: -67.8094253540039\n",
+       "}\n",
+       "neighbor {\n",
+       "  id: \"4RzpCjByV1NWUGKVQGuej6\"\n",
+       "  distance: -67.86714172363281\n",
+       "}"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "channel = grpc.insecure_channel(\"{}:10000\".format(DEPLOYED_INDEX_SERVER_IP))\n",
+    "stub = match_service_pb2_grpc.MatchServiceStub(channel)\n",
+    "\n",
+    "# Test query\n",
+    "query = [\n",
+    "    -0.11333,\n",
+    "    0.48402,\n",
+    "    0.090771,\n",
+    "    -0.22439,\n",
+    "    6.034206,\n",
+    "    -7.55831,\n",
+    "    0.041849,\n",
+    "    -0.53573,\n",
+    "    0.18809,\n",
+    "    -0.58722,\n",
+    "    -1.015313\n",
+    "]\n",
+    "\n",
+    "request = match_service_pb2.MatchRequest()\n",
+    "request.deployed_index_id = DEPLOYED_INDEX_ID\n",
+    "for val in query:\n",
+    "    request.float_val.append(val)\n",
+    "\n",
+    "response = stub.Match(request)\n",
+    "response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8bd8b228-c929-4ab4-9b1f-4eb6a564656a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fc3085d8-becd-49f7-b59d-c264b4579e41",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['test']"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (Local)",
+   "language": "python",
+   "name": "local-base"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Related Issue
- #22 

## Description
- Following #2, we are primarily interested in training and deploying a Vertex AI ANN index for our Spotify song embeddings. This pull request is created to show how our ANN index can be deployed programmatically for recommendations.
  - This pull request contains a notebook created as a spike for learning how to use the [Python documentation](https://cloud.google.com/python/docs/reference/aiplatform/latest) for `google-cloud-aiplatform`. The notebook illustrates our strategy for integration with our ANN service:
    1.    During integration with our REST API, we adopt the precondition that an ANN index is pre-built during deployment for the target region. For instance, if our web service is deployed in `us-west1c` (Oregon), then we assume an ANN index is available in `us-west1c` as well. This is due to the fact that the [match service gRPC API](https://github.com/googleapis/googleapis) is used to call the deployed ANN index service and has a precondition that gRPC calls must be in the same region.
    2. The [/list_index_endpoints](https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.services.index_endpoint_service.IndexEndpointServiceClient#google_cloud_aiplatform_v1_services_index_endpoint_service_IndexEndpointServiceClient_list_index_endpoints) endpoint on the index endpoint service is used in order to retrieve the index endpoints for the region of deployment.
    3. If there is no deployment from the `index endpoints` in our current region, then the [/list_indexes](https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.services.index_service.IndexServiceClient#google_cloud_aiplatform_v1_services_index_service_IndexServiceClient_list_indexes) endpoint on the index service is used in order to retrieve the index name to use for deployment. [/deploy_index](https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.services.index_endpoint_service.IndexEndpointServiceClient#google_cloud_aiplatform_v1_services_index_endpoint_service_IndexEndpointServiceClient_deploy_index) endpoint is finally called in order to deploy an ANN index.
    4. Once a [deployed index](https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.types.DeployedIndex) is available, the gRPC address can be retrieved to get recommendations from our deployed ANN index.
  - The below screenshot shows a sample request from a deployed ANN index for an arbitrary track embedding.


<!-- Brief but accurate description for issues and solution proposed -->

## Tests Included
- [ ] Unit tests
- [ ]  Integration tests
- [X] Environment tests
- [ ] Regression tests
- [X] Smoke tests

## Screenshots
<img width="889" alt="Screen Shot 2022-06-20 at 4 15 09 PM" src="https://user-images.githubusercontent.com/10148029/174688347-d117009d-ad8c-4179-972c-8f1a6771a156.png">

<!-- Optional if screenshots provide clarity/context -->
