### PR TITLE
Onboard environment based config handling strategy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.8-slim-buster
 
+ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 COPY requirements.txt requirements.txt
 COPY src/api/ .

--- a/deployment.yml
+++ b/deployment.yml
@@ -38,6 +38,8 @@ spec:
           value: "spotify-rest-api-secret"
         - name: SECRET_VERSION_ID
           value: "latest"
+        - name: ENVIRONMENT
+          value: "staging"
 ---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -2,11 +2,25 @@ from flask import Flask, Blueprint
 from .routes.reco import reco
 from .routes.healthcheck import healthcheck
 from flasgger import Swagger
+import json
+import os
+
+CONFIG_PATH = './config/'
+def load_config(app: Flask, config_env: str):
+    config_file = '{}{}.json'.format(CONFIG_PATH, config_env)
+    print('Config file: {}'.format(config_file))
+    app.config.from_file(config_file, load=json.load)
 
 v1 = Blueprint('name', __name__)
 flask_app = Flask(__name__)
 
+load_config(flask_app, 'default')
+config_env = os.environ['ENVIRONMENT']
+load_config(flask_app, config_env)
+
 swagger = Swagger(flask_app)
+
+print('Value of TEST in config: {}'.format(flask_app.config['TEST']))
 
 v1.register_blueprint(reco, url_prefix='/reco')
 flask_app.register_blueprint(v1, url_prefix='/v1')

--- a/src/api/config/default.json
+++ b/src/api/config/default.json
@@ -1,0 +1,3 @@
+{
+    "TEST": "default"
+}

--- a/src/api/config/development.json
+++ b/src/api/config/development.json
@@ -1,0 +1,3 @@
+{
+    "TEST": "development"
+}

--- a/src/api/config/staging.json
+++ b/src/api/config/staging.json
@@ -1,0 +1,3 @@
+{
+    "TEST": "development"
+}


### PR DESCRIPTION
## Related Issue
- #48  

## Description
- We are interested in adding differing configurations between development and staging environments, such as the mock client configuration setup for development in #47 (host URL, client timeout, etc.). This pull request is created in order to introduce a strategy for configuration for each environment.
  - In order to add differing configurations, [configuration handling](https://flask.palletsprojects.com/en/2.1.x/config/) from the Flask documentation was used. Specifically, an environment variable `ENVIRONMENT` is used to determine which config to load:
    - If this key has `development` value, then `development.json` config is loaded.
    - Similarly, if this key has `staging` value, then `staging.json` config is loaded.
    - For all other environments, we provide `default.json` config as a fallback.
- In order to test these changes, smoke tests were performed on a Kubernetes cluster on my local machine. The screenshot below shows the `TEST` field being loaded from `development.json` on one of the pods used.

## Tests Included
- [ ] Unit tests
- [ ]  Integration tests
- [ ] Environment tests
- [ ] Regression tests
- [X] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
<img width="611" alt="Screen Shot 2022-08-27 at 6 21 35 PM" src="https://user-images.githubusercontent.com/10148029/187053751-1389a135-91a3-423d-8b23-26d93440a05d.png">

