### PR TITLE
Error handling for 400 response from /v1/audio-features

### DIFF
--- a/src/api/util/reco_adapter.py
+++ b/src/api/util/reco_adapter.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from http import HTTPStatus
 from urllib.error import HTTPError
+from requests import HTTPError as ClientHTTPError
 from ..clients.spotify_client.client import Client as SpotifyClient
 from ..clients.logging_client.client import Client as LoggingClient
 from ..clients.matching_engine_client.client_aggregator import ClientAggregator
@@ -36,8 +37,11 @@ class V1RecoAdapter(RecoAdapter):
             recos_dict = MessageToDict(recos, including_default_value_fields=True, preserving_proto_field_name=False)
             recos_response = self.response_builder_factory.get_builder(status_code=HTTPStatus.OK.value).build_response(recos_response=recos_dict, id=id, size=size)
         except HTTPError as http_error:
-            print(http_error.msg)
+            print(http_error.__str__())
             recos_response = self.response_builder_factory.get_builder(status_code=http_error.code).build_response(recos_response=recos_dict, id=id, size=size)
+        except ClientHTTPError as client_http_error:
+            print(client_http_error.__str__())
+            recos_response = self.response_builder_factory.get_builder(status_code=client_http_error.response.status_code).build_response(recos_response=recos_dict, id=id, size=size)
         
         return recos_response
     

--- a/test/unit_tests/api/util/test_reco_adapter.py
+++ b/test/unit_tests/api/util/test_reco_adapter.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from urllib.error import HTTPError
+from requests import HTTPError as ClientHTTPError, Response
 from unittest.mock import patch, Mock
 from src.api.util.reco_adapter import V1RecoAdapter
 from src.api.schemas.response import BadRequestResponseBuilder, NotFoundResponseBuilder, OkResponseBuilder
@@ -64,14 +64,16 @@ class V1RecoAdapterTestSuite(unittest.TestCase):
 
         self.assertEqual(200, response['status'])
 
-    def test_should_return_404_response_on_invalid_track_id(self) -> None:
+    def test_should_return_400_response_on_invalid_track_id(self) -> None:
         def side_effect(id):
-            raise HTTPError(None, HTTPStatus.NOT_FOUND.value, 'Track not found', None, None)
+            response = Mock(Response)
+            response.status_code = 400
+            raise ClientHTTPError(response=response)
         self.reco_adapter.spotify_client.v1_audio_features.side_effect = side_effect
 
         response = self.reco_adapter.get_recos(id='id', size='5')
 
-        self.assertEqual(404, response['status'])
+        self.assertEqual(400, response['status'])
 
     def test_should_return_400_response_on_invalid_reco_size_value(self) -> None:
         response = self.reco_adapter.get_recos(id='id', size='0')


### PR DESCRIPTION
## Related Issue
<!-- Related issues go here -->
#60 

## Description
- Currently, a 400 response from our `/v1/audio-features` API client causes a 500 response on `/v1/reco/{id}` API. This pull request is created in order to adapt the error handling code to instead return a 400 response.
  - We initially wanted to return a 404 response code, but decide to propagate the original 400 response from `/v1/audio-features` since this Spotify API does not ever return a 404 response code.
- In order to test these changes, c6f0cd35a228b1f7efb18e5b2689fe65d077af5a introduces a refactor to the relevant unit test suites. Additionally, environment tests were performed on our GKE cluster in order to verify that the correct API response code is used.
<!-- Brief but accurate description for issues and solution proposed -->

## Tests Included
- [X] Unit tests
- [ ]  Integration tests
- [X] Environment tests
- [ ] Regression tests
- [X] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
<img width="1680" alt="Screen Shot 2022-09-05 at 3 37 46 PM" src="https://user-images.githubusercontent.com/10148029/188517979-04d899cb-8ba0-48c3-b564-59d8e55ae5a5.png">
