### PR TITLE
Add service call response to cloud logging for Spotify API client

### DIFF
--- a/src/api/clients/spotify_client/client.py
+++ b/src/api/clients/spotify_client/client.py
@@ -32,6 +32,8 @@ class SpotifyClient(Client):
         if marketplace:
             batch.log('marketplace={}'.format(marketplace), severity='INFO')
             endpoint = '{}?market={}'.format(endpoint, marketplace)
+        else:
+            batch.log('marketplace query param omitted.', severity='INFO')
 
         bearer_token = self.get_bearer_token()
 
@@ -40,6 +42,7 @@ class SpotifyClient(Client):
         }
 
         response = requests.get(endpoint, headers=headers)
+        batch.log('status={}'.format(response.status_code), severity='NOTICE')
         response.raise_for_status()
         response_json = response.json()
         batch.log('response={}'.format(response_json), severity='INFO')
@@ -61,6 +64,7 @@ class SpotifyClient(Client):
         }
 
         response = requests.get(endpoint, headers=headers)
+        batch.log('status={}'.format(response.status_code), severity='NOTICE')
         response.raise_for_status()
         response_json = response.json()
         batch.log('response={}'.format(response_json), severity='INFO')


### PR DESCRIPTION
## Related Issue
#65 

## Description
- Troubleshooting issues that happen in GKE on Google Cloud is currently difficult due to a lack of instrumentation. This pull request introduces additional monitoring for the Spotify API client.
  - `v1/audio-features/{id}` and `v1/tracks/{id}` resources are currently used in order to create track embeddings for getting track recommendations. Due to a lack of logging where the service call is being made, it is difficult to trace issues from this part of our service. 30c57e9509f46bdca560bed217b73ac89864f08c and f4588e9ae789847278c82ccfe7cdf932b7c5e5da were added in order to address this issue.
  - In order to test these changes, we deployed our changes to GKE and used Cloud Logging explorer to query the newly added logs. Since our strategy names logs at the module level, we can query for module activity in our code by the module name directly.
<!-- Brief but accurate description for issues and solution proposed -->

## Tests Included
- [ ] Unit tests
- [ ]  Integration tests
- [X] Environment tests
- [X] Regression tests
- [X] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
<img width="1680" alt="Screen Shot 2022-10-05 at 9 45 36 PM" src="https://user-images.githubusercontent.com/10148029/194223529-b9faafd8-9e7d-4872-a610-7b5e2f49901e.png">
<img width="1680" alt="Screen Shot 2022-10-05 at 9 45 25 PM" src="https://user-images.githubusercontent.com/10148029/194223543-ad385e93-202b-431b-b159-571a6e86876d.png">
