### PR TITLE
Added integration tests for Spotify authentication service client 

### DIFF
--- a/src/api/routes/reco.py
+++ b/src/api/routes/reco.py
@@ -119,6 +119,7 @@ reco = Blueprint('reco', __name__)
 })
 def id(id):
     response = None
+    size = request.args.get(key='size') or str(5)
 
     response_builder_factory = ResponseBuilderFactory()
     try:
@@ -132,7 +133,6 @@ def id(id):
         client_aggregator = ClientAggregator(config_facade=config_facade, mock_match_service_client=MockMatchServiceClient, match_service_client=MatchServiceClient)
         reco_adapter = V1RecoAdapter(spotify_client=spotify_client, logging_client=logging_client, client_aggregator=client_aggregator, response_builder_factory=response_builder_factory)
         
-        size = request.args.get(key='size') or str(5)
         
         response = reco_adapter.get_recos(id=id, size=size)
     except Exception as exception:

--- a/test/integration_tests/api/clients/spotify_auth_client/test_client.py
+++ b/test/integration_tests/api/clients/spotify_auth_client/test_client.py
@@ -1,6 +1,8 @@
 import unittest
+from unittest.mock import Mock
 from src.api.clients.spotify_auth_client.client import SpotifyAuthClient
 from src.api.clients.logging_client.client import LoggingClient
+from requests import HTTPError
 
 class SpotifyClientTestSuite(unittest.TestCase):
     def setUp(self) -> None:
@@ -8,7 +10,12 @@ class SpotifyClientTestSuite(unittest.TestCase):
         self.auth_client = SpotifyAuthClient(logging_client=logging_client)
     
     def test_should_return_bearer_token_for_valid_basic_authorization(self) -> None:
-        pass
+        bearer_token_dict = self.auth_client.get_bearer_token()
+        self.assertIsNotNone(bearer_token_dict)
+        self.assertIsNotNone(bearer_token_dict['access_token'])
+        self.assertEqual('Bearer', bearer_token_dict['token_type'])
+        self.assertIsNotNone(bearer_token_dict['expires_in'])
 
     def test_should_not_return_bearer_token_for_invalid_basic_authorization(self) -> None:
-        pass
+        self.auth_client.get_basic_token = Mock(return_value='invalid_basic_token')
+        self.assertRaises(HTTPError, self.auth_client.get_bearer_token)

--- a/test/integration_tests/api/clients/spotify_auth_client/test_client.py
+++ b/test/integration_tests/api/clients/spotify_auth_client/test_client.py
@@ -1,0 +1,14 @@
+import unittest
+from src.api.clients.spotify_auth_client.client import SpotifyAuthClient
+from src.api.clients.logging_client.client import LoggingClient
+
+class SpotifyClientTestSuite(unittest.TestCase):
+    def setUp(self) -> None:
+        logging_client = LoggingClient()
+        self.auth_client = SpotifyAuthClient(logging_client=logging_client)
+    
+    def test_should_return_bearer_token_for_valid_basic_authorization(self) -> None:
+        pass
+
+    def test_should_not_return_bearer_token_for_invalid_basic_authorization(self) -> None:
+        pass


### PR DESCRIPTION
## Related Issue
- #71 
<!-- Related issues go here -->

## Description
- Currently, we only have [integration tests](https://github.com/NoahT/spotifind-flask-api/issues/71) for `/v1/audio-features` API client. We should have integration tests for all calling clients in order to catch failures before deployments to our GKE cluster. This pull request is created to add integration tests for the [/api/token](https://developer.spotify.com/documentation/general/guides/authorization/client-credentials/) API client.
  - To test these changes, integration tests were ran locally using the [Dockerfile](https://github.com/NoahT/spotifind-flask-api/blob/e5e9c83eec8dc9a6bc69b6b9f8fcd2aaff853edd/test/integration_tests/Dockerfile) intended for integration testing.  The screenshot below shows the newly added integration tests passing during a recent deployment to our GKE cluster.
- This pull request also couples changes from 39891d0d443ee493d807a9002130bf0ddaed1be7. During the non-happy path use case, `size` reference is undefined which causes 5xx exceptions to be re-thrown instead of the error handling introduced in #62.

## Tests Included
- [ ] Unit tests
- [X]  Integration tests
- [X] Environment tests
- [ ] Regression tests
- [X] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
<img width="1680" alt="Screen Shot 2022-11-27 at 7 50 41 PM" src="https://user-images.githubusercontent.com/10148029/204190279-e7860937-18d5-4820-bdd9-a540378bcb81.png">
