### PR TITLE
Refactor authentication service client to store Bearer tokens in memory

### DIFF
--- a/deployment.yml
+++ b/deployment.yml
@@ -44,7 +44,7 @@ spec:
         - name: SECRET_VERSION_ID
           value: "latest"
         - name: ENVIRONMENT
-          value: "staging"
+          value: "development"
 ---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler

--- a/deployment.yml
+++ b/deployment.yml
@@ -44,7 +44,7 @@ spec:
         - name: SECRET_VERSION_ID
           value: "latest"
         - name: ENVIRONMENT
-          value: "development"
+          value: "staging"
 ---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,5 +1,4 @@
 from flask import Flask, Blueprint
-from .routes.reco import reco
 from .routes.healthcheck import healthcheck
 from flasgger import Swagger
 import json
@@ -11,17 +10,23 @@ def load_config(app: Flask, config_env: str):
     print('Config file: {}'.format(config_file))
     app.config.from_file(config_file, load=json.load)
 
-v1 = Blueprint('name', __name__)
+def load_blueprints(app: Flask):
+    from .routes.reco import reco
+
+    v1 = Blueprint('name', __name__)
+    swagger = Swagger(app)
+
+    v1.register_blueprint(reco, url_prefix='/reco')
+    app.register_blueprint(v1, url_prefix='/v1')
+
+    # For health checks on Ingress load balancer in GCP
+    app.register_blueprint(healthcheck)
+
 flask_app = Flask(__name__)
+flask_app.app_context().push()
 
 load_config(flask_app, 'default')
 config_env = os.environ['ENVIRONMENT']
 load_config(flask_app, config_env)
 
-swagger = Swagger(flask_app)
-
-v1.register_blueprint(reco, url_prefix='/reco')
-flask_app.register_blueprint(v1, url_prefix='/v1')
-
-# For health checks on Ingress load balancer in GCP
-flask_app.register_blueprint(healthcheck)
+load_blueprints(flask_app)

--- a/src/api/clients/spotify_auth_client/client.py
+++ b/src/api/clients/spotify_auth_client/client.py
@@ -28,7 +28,7 @@ class SpotifyAuthClient(Client):
         token = self.get_bearer_token_from_cache(key='public')
         return token
     
-    @cached(cache=TTLCache(maxsize=1, ttl=60))
+    @cached(cache=TTLCache(maxsize=1, ttl=3600))
     def get_bearer_token_from_cache(self, key='public') -> dict:
         # By default public scope is only scope we can use for client credentials. When we look into adding a
         # resource for creating playlists we will need to use a new authentication flow that propagates a token

--- a/src/api/config/config_facade.py
+++ b/src/api/config/config_facade.py
@@ -2,8 +2,10 @@ import flask
 
 class ConfigFacade():
     def __init__(self) -> None:
-        self.environment = flask.current_app.config['ENVIRONMENT']
-        self.match_service_enabled = flask.current_app.config['MATCH_SERVICE_ENABLED']
+        app = flask.current_app
+        with app.app_context():
+            self.environment = flask.current_app.config['ENVIRONMENT']
+            self.match_service_enabled = flask.current_app.config['MATCH_SERVICE_ENABLED']
     
     def get_environment(self) -> str:
         return self.environment

--- a/src/api/routes/reco.py
+++ b/src/api/routes/reco.py
@@ -1,6 +1,5 @@
 from http import HTTPStatus
 from flask import Blueprint, request
-from flasgger import swag_from
 from ..config.config_facade import ConfigFacade
 from ..clients.matching_engine_client.client_aggregator import ClientAggregator
 from ..clients.matching_engine_client.client import MockMatchServiceClient, MatchServiceClient
@@ -12,130 +11,25 @@ from ..util.reco_adapter import V1RecoAdapter
 
 reco = Blueprint('reco', __name__)
 
-@reco.route('/<id>', methods=['GET'])
-@swag_from({
-    "parameters": [
-        {
-            "name": "size",
-            "in": "query",
-            "type": "int",
-            "required": False,
-            "default": "5"
-        },
-        {
-            "name": "id",
-            "in": "path",
-            "type": "string",
-            "required": True
-        }
-    ],
-    "definitions": {
-        "response": {
-            "type": "object",
-            "properties": {
-                "request": {
-                    "$ref": "#/definitions/request_200"
-                },
-                "recos": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/track"
-                    }
-                }
-            }
-        },
-        "request_200": {
-            "description": "/id 200 response",
-            "type": "object",
-            "properties": {
-                "track": {
-                    "$ref": "#/definitions/track"
-                },
-                "size": {
-                    "type": "integer"
-                }
-            }
-        },
-        "request_4xx": {
-            "description": "/id 4xx response",
-            "type": "object",
-            "properties": {
-                "status": {
-                    "type": "integer"
-                },
-                "message": {
-                    "type": "string"
-                }
-            }
-        },
-        "track": {
-            "description": "Model object for Spotify track metadata",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                }
-            }
-        }
-    },
-    "responses": {
-        "200": {
-            "description": "A list of track ids.",
-            "schema": {
-                "$ref": "#/definitions/response"
-            },
-            "examples": {
-                "Happy path": {
-                    "summary": "Happy path/valid track id",
-                    "value": {
-                        "request": {
-                            "track": {
-                                "id": "62BGM9bNkNcvOh13B4wOyr"
-                            },
-                            "size": 5
-                        },
-                        "recos": [
-                            {
-                                "id": "2TRu7dMps7cVKOyazkj9Fb"
-                            },
-                            {
-                                "id": "0bqrFwY1HixfnusFxhYbDl"
-                            },
-                            {
-                                "id": "4BHSjbYylfOH5WAGusDyni"
-                            },
-                            {
-                                "id": "3s9f1LQ6607eDj9UYCzmgk"
-                            },
-                            {
-                                "id": "2HbKqm4o0w5wEeEFXm2sD4"
-                            },
-                        ]
-                    }
-                }
-            }
-        }
-    }
-})
+response_builder_factory = ResponseBuilderFactory()
+
+config_facade = ConfigFacade()
+print('Environment: {}'.format(config_facade.get_environment()))
+print('Is match service enabled: {}'.format(config_facade.is_match_service_enabled()))
+
+logging_client = LoggingClient()
+spotify_auth_client = SpotifyAuthClient(logging_client=logging_client)
+spotify_client = SpotifyClient(auth_client=spotify_auth_client, logging_client=logging_client)
+client_aggregator = ClientAggregator(config_facade=config_facade, mock_match_service_client=MockMatchServiceClient, match_service_client=MatchServiceClient)
+reco_adapter = V1RecoAdapter(spotify_client=spotify_client, logging_client=logging_client, client_aggregator=client_aggregator, response_builder_factory=response_builder_factory)
+
 def id(id):
     response = None
     size = request.args.get(key='size') or str(5)
 
-    response_builder_factory = ResponseBuilderFactory()
     try:
-        config_facade = ConfigFacade()
-        print('Environment: {}'.format(config_facade.get_environment()))
-        print('Is match service enabled: {}'.format(config_facade.is_match_service_enabled()))
-
-        logging_client = LoggingClient()
-        spotify_auth_client = SpotifyAuthClient(logging_client=logging_client)
-        spotify_client = SpotifyClient(auth_client=spotify_auth_client, logging_client=logging_client)
-        client_aggregator = ClientAggregator(config_facade=config_facade, mock_match_service_client=MockMatchServiceClient, match_service_client=MatchServiceClient)
-        reco_adapter = V1RecoAdapter(spotify_client=spotify_client, logging_client=logging_client, client_aggregator=client_aggregator, response_builder_factory=response_builder_factory)
-        
-        
         response = reco_adapter.get_recos(id=id, size=size)
-    except Exception as exception:
+    except Exception:
         response = response_builder_factory.get_builder(status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value).build_response(recos_response=None, id=id, size=size)
     finally:
         print(response.__str__())


### PR DESCRIPTION
## Related Issue
- #70

## Description
- Our Spotify authentication service client makes a service call to Spotify's `/api/token` API resource every time the `GET::/v1/reco/{id}` resource is invoked. This service call is not necessary the majority of the time, since the Bearer tokens returned have an expiry that allows us to store the token in memory for subsequent requests. This issue is created in order to store these Bearer tokens in memory to reduce the overhead in latency for the `GET::/v1/reco/{id}` API.
  - We are primarily interested in reducing the overhead in latency caused by the service call needed for the client credentials flow. The adopted strategy is to use [cachetools](https://cachetools.readthedocs.io/en/latest/#), which is a python module that allows for easily integrating an in-memory cache with our web service.
  - Initially the choice between a _distributed_ and _in-memory_ cache was discussed. An in-memory cache was used for the following reasons:
    - **No concern for read consistency:** This is only used to cache Bearer tokens. Different bearer tokens on two separate pods with the same authorization scope in Kubernetes can still be used to get the same resource state from Spotfy APIs.
    - **Small quantity of objects needed for caching:** We only need to cache the Bearer token when it is still valid and can keep the cache size fixed at one.
    - **Distributed cache adds another component at system level:** We should be conservative with the number of services to maintain. Any unnecessary work we do over a network compromises our availability.
  - An LRU cache (any eviction policy would work) is used here with fixed size one and TTL of 3600 seconds since the only concern we have is the expiry of Bearer tokens after one hour.
  - We did not deploy the downstream gRPC service for recommendations since this deployment takes an hour. To verify a successful CD pipeline run, changes from a8f3783827299936e499ce99826efe566df0f94b were used temporarily in order to use the mock match service client during the deployment.
  - Note that a123793 also removes the changes added with swagger. Since the README.md already describes the contract for the resources used on this API, it is best to maintain the markdown as a single source of truth.

## Tests Included
- [ ] Unit tests
- [X]  Integration tests
- [X] Environment tests
- [ ] Regression tests
- [X] Smoke tests

## Screenshots
<img width="1680" alt="Screen Shot 2022-12-05 at 10 08 59 PM" src="https://user-images.githubusercontent.com/10148029/205836652-7c1e0711-084e-4b1c-8f77-99d8a5c5d0cf.png">

<!-- Optional if screenshots provide clarity/context -->
