### PR TITLE
Refactor Kubernetes pod autoscaling to use HorizontalPodAutoscaler from autoscaling/v2 API version instead of autoscaling/v2beta1

### DIFF
--- a/deployment.yml
+++ b/deployment.yml
@@ -46,7 +46,7 @@ spec:
         - name: ENVIRONMENT
           value: "staging"
 ---
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: spotifind-autoscaler
@@ -64,7 +64,9 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: 80
+      target:
+        type: Utilization
+        averageUtilization: 80
 ---
 apiVersion: v1
 kind: Service

--- a/src/api/routes/reco.py
+++ b/src/api/routes/reco.py
@@ -23,6 +23,7 @@ spotify_client = SpotifyClient(auth_client=spotify_auth_client, logging_client=l
 client_aggregator = ClientAggregator(config_facade=config_facade, mock_match_service_client=MockMatchServiceClient, match_service_client=MatchServiceClient)
 reco_adapter = V1RecoAdapter(spotify_client=spotify_client, logging_client=logging_client, client_aggregator=client_aggregator, response_builder_factory=response_builder_factory)
 
+@reco.route('/<id>', methods=['GET'])
 def id(id):
     response = None
     size = request.args.get(key='size') or str(5)


### PR DESCRIPTION
## Related Issue
- #78 
<!-- Related issues go here -->

## Description
- `autoscaling/v2beta2` API version for HorizontalPodAutoscaler resource in Kubernetes is deprecated as of version [1.26](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126). This issue is created in order to refactor the Kubernetes deployment file to instead use HorizontalPodAutoscaler resource from API version `autoscaling/v2`.
  - Since API version `autoscaling/v2beta2` is not backwards compatible with API version `autoscaling/v2`, the [documentation](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2/#HorizontalPodAutoscalerSpec) for the HorizontalPodAutoscaler specification was used in order to create an equivalent resource in 9922e3bf2cc070a56224ec0142bee25a39955678.
  - In order to test these changes, smoke tests in the screenshot below were performed with minikube to verify that changes to the Kubernetes deployment file do not affect build stability.
- This pull request also couples a fix from a breaking change in #79 that accidentally removed the API resource. This was not caught during regression tests since no integration tests exist for `GET::/v1/reco/{id*}`.
<!-- Brief but accurate description for issues and solution proposed -->

## Tests Included
- [ ] Unit tests
- [ ]  Integration tests
- [ ] Environment tests
- [ ] Regression tests
- [X] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
<img width="874" alt="Screen Shot 2022-12-10 at 1 16 50 AM" src="https://user-images.githubusercontent.com/10148029/206843171-6f799fae-8d02-4bdd-bb29-dd4428dc7941.png">
