### PR TITLE
Configure a domain name with Cloud DNS for Ingress external IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Spotifind is a REST web service. Any HTTP client can be used in order to interfa
 ### Endpoints
 Spotifind API is exposed behind two endpoints:
 
-1. **34.160.143.178 (external IP)**: This is our external IP currently configured in Google Cloud for edge routing (this is prone to change since we have not yet configured a domain). This is currently deployed in the [us-west1-c zone](https://cloud.google.com/compute/docs/regions-zones).
+1. **spotifind-api.com**: This is our endpoint configured in Google Cloud.
 2. **localhost (loopback address)**: This is used during development on a local machine.
 
 ### Resources

--- a/deployment.yml
+++ b/deployment.yml
@@ -44,7 +44,7 @@ spec:
         - name: SECRET_VERSION_ID
           value: "latest"
         - name: ENVIRONMENT
-          value: "staging"
+          value: "development"
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/deployment.yml
+++ b/deployment.yml
@@ -44,7 +44,7 @@ spec:
         - name: SECRET_VERSION_ID
           value: "latest"
         - name: ENVIRONMENT
-          value: "development"
+          value: "staging"
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
## Related Issue
<!-- Related issues go here -->
- #82 

## Description
- The endpoint we use for requests on our cluster in GKE uses an external IP address for the Ingress load balancer. We should configure a domain name with [Cloud DNS](https://cloud.google.com/dns/docs/overview) so calling clients have a looser coupling to the physical address. This issue is created in order to configure a domain name for this external IP address.
  - In order to properly configure our domain name, we followed the guide from the documentation [here](https://cloud.google.com/dns/docs/set-up-dns-records-domain-name) in order to correctly configure the DNS records to point to the external IP currently used. The screenshot below contains a smoke test that was done after configuring the DNS in order to verify that the record sets added point to the external IP of the Ingress resource.
  - 7fb968c3b9068de7dc88c21c48d262cc121fd508 also updates the `README.md` with the domain configured.
<!-- Brief but accurate description for issues and solution proposed -->

## Tests Included
- [ ] Unit tests
- [ ]  Integration tests
- [ ] Environment tests
- [ ] Regression tests
- [X] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
![Screen Shot 2022-12-11 at 1 51 26 AM](https://user-images.githubusercontent.com/10148029/206897427-65c2f47b-9c46-468d-baab-5cd8f226b072.jpeg)
