### PR TITLE
Integrate Cloud Build with private worker pool for `v1/reco/{id*}` integration tests

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -44,3 +44,5 @@ images:
 - gcr.io/${PROJECT_ID}/spotifind-integration-test
 options:
   logging: CLOUD_LOGGING_ONLY
+  pool:
+    name: 'projects/spotifind-api/locations/us-west1/workerPools/spotifind-api-private-pool'

--- a/src/api/routes/reco.py
+++ b/src/api/routes/reco.py
@@ -9,6 +9,8 @@ from ..clients.logging_client.client import LoggingClient
 from ..schemas.response import ResponseBuilderFactory
 from ..util.reco_adapter import V1RecoAdapter
 
+import json
+
 reco = Blueprint('reco', __name__)
 
 response_builder_factory = ResponseBuilderFactory()
@@ -33,6 +35,6 @@ def id(id):
     except Exception:
         response = response_builder_factory.get_builder(status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value).build_response(recos_response=None, id=id, size=size)
     finally:
-        print(response.__str__())
+        print(json.dumps(response.response))
 
     return response.response, response.response_code

--- a/src/api/schemas/response.py
+++ b/src/api/schemas/response.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 from http import HTTPStatus
 from abc import ABC
+import json
 
 class Response():
     def __init__(self, response: dict, response_code: int) -> None:
@@ -50,7 +51,7 @@ class OkResponseBuilder(ResponseBuilder):
         self._response_code = HTTPStatus.OK.value
     
     def build_response(self, recos_response: dict, id: str, size: int) -> Response:
-        print(recos_response.__str__())
+        print(json.dumps(recos_response))
         response = {
             'request': {
                 'track': {

--- a/test/integration_tests/Dockerfile
+++ b/test/integration_tests/Dockerfile
@@ -13,5 +13,6 @@ ENV PROJECT_NAME="spotifind-api"
 ENV CLIENT_ID="081f994d972f46519c1c8f9f6f11102a"
 ENV SECRET_ID="spotify-rest-api-secret"
 ENV SECRET_VERSION_ID="latest"
+ENV ENVIRONMENT="staging"
 
 CMD [ "python3", "-m", "unittest", "discover", "-s", "./test/integration_tests/" ]

--- a/test/integration_tests/routes/test_reco_id.py
+++ b/test/integration_tests/routes/test_reco_id.py
@@ -1,0 +1,68 @@
+import unittest
+from src.api.app import flask_app
+
+class RecosAPITestSuite(unittest.TestCase):
+    def setUp(self) -> None:
+        self.spotifind_client = flask_app.test_client()
+    
+    def test_should_return_200_response_for_valid_id(self) -> None:
+        recos_response = self.spotifind_client.get('/v1/reco/3L4KeuZsCf5PHkXPvvvCQG')
+        recos_response_json = recos_response.json
+
+        self.assertIsNotNone(recos_response_json)
+        
+        recos = recos_response_json['recos']
+        self.assertIsNotNone(recos)
+        self.assertEqual(len(recos), 5)
+
+        request = recos_response_json['request']
+        self.assertIsNotNone(request)
+        self.assertEqual(request,
+        {
+            'size': '5',
+            'track': {
+                'id': '3L4KeuZsCf5PHkXPvvvCQG'
+            }
+        })
+        
+    def test_should_return_200_response_for_valid_id_with_size(self) -> None:
+        recos_response = self.spotifind_client.get('/v1/reco/3L4KeuZsCf5PHkXPvvvCQG?size=50')
+        recos_response_json = recos_response.json
+
+        self.assertIsNotNone(recos_response_json)
+
+        recos = recos_response_json['recos']
+        self.assertIsNotNone(recos)
+        self.assertEqual(len(recos), 50)
+        
+        request = recos_response_json['request']
+        self.assertIsNotNone(request)
+        self.assertEqual(request,
+        {
+            'size': '50',
+            'track': {
+                'id': '3L4KeuZsCf5PHkXPvvvCQG'
+            }
+        })
+
+    def test_should_return_400_response_for_invalid_size(self) -> None:
+        recos_response = self.spotifind_client.get('/v1/reco/3L4KeuZsCf5PHkXPvvvCQG?size=-1')
+        recos_response_json = recos_response.json
+
+        self.assertIsNotNone(recos_response_json)
+        self.assertEqual(recos_response_json,
+        {
+            "message": "Bad request.",
+            "status": 400
+        })
+
+    def test_should_return_400_response_for_invalid_track(self) -> None:
+        recos_response = self.spotifind_client.get('/v1/reco/invalid_resource')
+        recos_response_json = recos_response.json
+
+        self.assertIsNotNone(recos_response_json)
+        self.assertEqual(recos_response_json,
+        {
+            "message": "Bad request.",
+            "status": 400
+        })


### PR DESCRIPTION
## Related Issue
<!-- Related issues go here -->
- #72

## Description
- Currently, we only have [integration tests](https://github.com/NoahT/spotifind-flask-api/issues/71) for REST clients integrating with Spotify. In order to catch failures with integration points before deployments to our GKE cluster, we should have integration tests anywhere in which two or more components interface. This issue is created in order to add integration tests for the `v1/reco/{id*}` API.
  - Integration testing for `v1/reco/{id*}` was initially deferred: since the gRPC service we use for recommendations is inside of a VPC, integration tests here would fail since compute nodes allocated for Cloud Build run outside of this VPC without any peering connection. We have since decided to adopt the use of a [private worker pool](https://cloud.google.com/build/docs/private-pools/private-pools-overview) in our Cloud Build pipeline. By doing so, a peering connection can be established which will allow for successful unary calls to our gRPC service.

## Tests Included
- [ ] Unit tests
- [X]  Integration tests
- [X] Environment tests
- [X] Regression tests
- [ ] Smoke tests

## Screenshots
<img width="1680" alt="Screen Shot 2023-01-05 at 12 18 37 AM" src="https://user-images.githubusercontent.com/10148029/210733548-8d79c5d1-b2e1-4bd3-a951-1bceb22afa32.png">
