### PR TITLE
Integration tests for unary RPC calls to matching engine service

### DIFF
--- a/test/integration_tests/api/clients/matching_engine_client/test_client.py
+++ b/test/integration_tests/api/clients/matching_engine_client/test_client.py
@@ -1,0 +1,51 @@
+import unittest
+from src.api.clients.matching_engine_client.client import MatchServiceClient
+from src.api.clients.matching_engine_client.match_service_pb2 import MatchResponse
+
+class MatchingEngineClientTestSuite(unittest.TestCase):
+    def setUp(self) -> None:
+        self.match_service_client = MatchServiceClient()
+    
+    def test_should_return_match_response_for_singular_reco(self) -> None:
+        match_request = {
+            'query': [
+                0.762,
+                0.213,
+                10,
+                -14.68,
+                1,
+                0.128,
+                0.52,
+                0,
+                0.0668,
+                0.105,
+                10.069
+            ],
+            'num_recos': 1
+        }
+        match_response = self.match_service_client.get_match(match_request=match_request)
+        self.assertIsNotNone(match_response)
+        self.assertIsNotNone(match_response.neighbor)
+        self.assertEqual(len(match_response.neighbor), 1)
+
+    def test_should_return_match_response_for_multiple_reco(self) -> None:
+        match_request = {
+            'query': [
+                0.762,
+                0.213,
+                10,
+                -14.68,
+                1,
+                0.128,
+                0.52,
+                0,
+                0.0668,
+                0.105,
+                10.069
+            ],
+            'num_recos': 5
+        }
+        match_response = self.match_service_client.get_match(match_request=match_request)
+        self.assertIsNotNone(match_response)
+        self.assertIsNotNone(match_response.neighbor)
+        self.assertEqual(len(match_response.neighbor), 5)


### PR DESCRIPTION
## Related Issue
<!-- Related issues go here -->
- #81 

## Description
- Currently, we only have [integration tests](https://github.com/NoahT/spotifind-flask-api/issues/71) for REST clients integrating with Spotify. In order to promote confidence in deployments from our CD pipeline, we should have integration tests for all integration points between our web service and downstream systems. This pull request introduces integration tests for the gRPC client to Vertex AI matching engine service.
  - This pull request adopts the same private worker pool strategy discussed in #86.

## Tests Included
- [ ] Unit tests
- [X]  Integration tests
- [X] Environment tests
- [X] Regression tests
- [ ] Smoke tests

## Screenshots
<img width="1680" alt="Screen Shot 2023-01-05 at 1 12 33 AM" src="https://user-images.githubusercontent.com/10148029/210743564-6b274fde-8fcc-43b8-9d07-cf023dc1e273.png">

