### PR TITLE
Added liveness and readiness probes to deployment spec.

### DIFF
--- a/deployment.yml
+++ b/deployment.yml
@@ -32,6 +32,18 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 5000
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 5000
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 5000
+          initialDelaySeconds: 5
+          periodSeconds: 5
         env:
         - name: PROJECT_ID
           value: "841506577075"


### PR DESCRIPTION
## Related Issue
<!-- Related issues go here -->
- #88 

## Description
- Changes from #35 introduce a health check for the backends serviced by our Ingress load balancer, but do not diagnose whether each associated pod is able to serve traffic. This pull request is created in order to also include [liveness and readiness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) in our Kubernetes deployment spec to determine whether pods are able to serve traffic.
  - To test these changes, I performed local environment tests with minikube in order to verify liveness and readiness probes are being fired. The screenshot below exposes the logs inside of one of the pods during our deployment with minikube.

## Tests Included
- [ ] Unit tests
- [ ]  Integration tests
- [X] Environment tests
- [ ] Regression tests
- [ ] Smoke tests

## Screenshots
<img width="778" alt="Screen Shot 2023-01-07 at 5 55 58 PM" src="https://user-images.githubusercontent.com/10148029/211177261-26d79203-eb04-4cb6-93e0-5f02a583b0c1.png">

