### PR TITLE
Add warmup to reduce overhead from client credentials code flow during first live request

### DIFF
--- a/deployment.yml
+++ b/deployment.yml
@@ -45,6 +45,38 @@ spec:
           value: "latest"
         - name: ENVIRONMENT
           value: "staging"
+      # Sidecar container for warmups. We take this example directly from the expedia group documentation
+      # https://opensource.expediagroup.com/mittens/docs/installation/running#run-as-a-sidecar-on-kubernetes
+      - name: mittens
+        image: expediagroup/mittens:latest
+        resources:
+          limits:
+            memory: 50Mi
+            cpu: 50m
+          requests:
+            memory: 50Mi
+            cpu: 50m
+        readinessProbe:
+          exec:
+            command:
+            - "cat"
+            - "ready"
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        livenessProbe:
+          exec:
+            command:
+            - "cat"
+            - "alive"
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        args:
+        - "--concurrency=1"
+        - "--exit-after-warmup=true"
+        - "--max-duration-seconds=60"
+        - "--target-http-port=5000"
+        - "--http-requests=get:/health"
+        - "--http-requests=get:/v1/reco/3qZlWVmqyr9BkZ6y4tdtsD?size=10"
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/deployment.yml
+++ b/deployment.yml
@@ -70,10 +70,8 @@ spec:
             cpu: 50m
         args:
         - "--concurrency=1"
-        - "--max-duration-seconds=120"
         - "--max-readiness-wait-seconds=60"
-        - "--max-warmup-seconds=60"
-        - "--exit-after-warmup=true"
+        - "--max-warmup-seconds=30"
         - "--fail-readiness=true"
         - "--file-probe-enabled=false"
         - "--target-readiness-http-path=/health"

--- a/deployment.yml
+++ b/deployment.yml
@@ -68,27 +68,20 @@ spec:
           requests:
             memory: 50Mi
             cpu: 50m
-        readinessProbe:
-          exec:
-            command:
-            - "cat"
-            - "ready"
-          initialDelaySeconds: 10
-          periodSeconds: 30
-        livenessProbe:
-          exec:
-            command:
-            - "cat"
-            - "alive"
-          initialDelaySeconds: 10
-          periodSeconds: 30
         args:
         - "--concurrency=1"
+        - "--max-duration-seconds=120"
+        - "--max-readiness-wait-seconds=60"
+        - "--max-warmup-seconds=60"
         - "--exit-after-warmup=true"
-        - "--max-duration-seconds=60"
+        - "--fail-readiness=true"
+        - "--file-probe-enabled=false"
+        - "--target-readiness-http-path=/health"
+        - "--target-readiness-http-host=http://localhost"
+        - "--target-readiness-port=5000"
+        - "--target-http-host=http://localhost"
         - "--target-http-port=5000"
-        - "--http-requests=get:/health"
-        - "--http-requests=get:/v1/reco/3qZlWVmqyr9BkZ6y4tdtsD?size=10"
+        - "--http-requests=get:/v1/reco/7cNNUbN90ArXvrfVUcdIO9?size=10"
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
## Related Issue
<!-- Related issues go here -->
- #77 

## Description
- We should add a warmup request in order to reduce the overhead from the service call needed to retrieve a Bearer token during the authorization code flow. This ensures that first live request will pick up a Bearer token from the in-memory cache instead of making a service call needed in the client credentials flow. This pull request is created in order to add a sidecar container to our [Kubernetes deployment file](https://github.com/NoahT/spotifind-flask-api/blob/64579ea5a5e3f340209a11214dd6fde039390936/deployment.yml#L29) with [mittens](https://github.com/ExpediaGroup/mittens) for warming up the `GET::/v1/reco/{id}` API.
  - We chose a sidecar container strategy with mittens since this allows us to couple an additional container inside of the same pod that contains our main container. Coupling in this context is okay; warmup requests naturally introduce a dependency due to the service they target. Consequently, our sidecar container with mittens will send warmup requests anytime a new pod is introduced to our Kubernetes deployment.

## Tests Included
- [ ] Unit tests
- [ ]  Integration tests
- [X] Environment tests
- [ ] Regression tests
- [X] Smoke tests

## Screenshots
<img width="1680" alt="Screen Shot 2023-01-08 at 5 53 17 PM" src="https://user-images.githubusercontent.com/10148029/211230397-b01497a3-d1d6-430b-9842-119b54d77c5c.png">
<img width="1202" alt="Screen Shot 2023-01-08 at 5 37 46 PM" src="https://user-images.githubusercontent.com/10148029/211230401-1ffce801-a0d9-4cd7-96d5-c6055a8d7302.png">

<!-- Optional if screenshots provide clarity/context -->
