### PR TITLE
Change gRPC unary request to use N+1 recos

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Response:
         }
     ],
     "request": {
-        "size": "5",
+        "size": 5,
         "track": {
             "id": "2TRu7dMps7cVKOyazkj9Fb"
         }

--- a/src/api/schemas/response.py
+++ b/src/api/schemas/response.py
@@ -61,10 +61,12 @@ class OkResponseBuilder(ResponseBuilder):
             }
         }
         recos = []
-        for reco in recos_response['neighbor']:
-            recos.append({ 'id': reco['id'] })
+        neighbors = recos_response['neighbor']
+        for reco in neighbors:
+            if id != reco['id']:
+                recos.append({ 'id': reco['id'] })
         
-        response['recos'] = recos
+        response['recos'] = recos[:size]
 
         return Response(response=response, response_code=self._response_code)
 

--- a/src/api/util/reco_adapter.py
+++ b/src/api/util/reco_adapter.py
@@ -30,12 +30,12 @@ class V1RecoAdapter(RecoAdapter):
             size_int = int(size)
             if size_int <= 0:
                 raise HTTPError(None, HTTPStatus.BAD_REQUEST.value, 'Unable to handle non-positive reco size.', None, None)
-            
+
             audio_features = self.spotify_client.v1_audio_features(id=id)
             track_embedding = self.get_embedding(audio_features=audio_features)
-            recos = self.match_service_client.get_match(match_request={'query': track_embedding, 'num_recos': size_int})
+            recos = self.match_service_client.get_match(match_request={'query': track_embedding, 'num_recos': (size_int + 1)})
             recos_dict = MessageToDict(recos, including_default_value_fields=True, preserving_proto_field_name=False)
-            recos_response = self.response_builder_factory.get_builder(status_code=HTTPStatus.OK.value).build_response(recos_response=recos_dict, id=id, size=size)
+            recos_response = self.response_builder_factory.get_builder(status_code=HTTPStatus.OK.value).build_response(recos_response=recos_dict, id=id, size=int(size))
         except HTTPError as http_error:
             print(http_error.__str__())
             recos_response = self.response_builder_factory.get_builder(status_code=http_error.code).build_response(recos_response=recos_dict, id=id, size=size)

--- a/test/integration_tests/routes/test_reco_id.py
+++ b/test/integration_tests/routes/test_reco_id.py
@@ -19,7 +19,7 @@ class RecosAPITestSuite(unittest.TestCase):
         self.assertIsNotNone(request)
         self.assertEqual(request,
         {
-            'size': '5',
+            'size': 5,
             'track': {
                 'id': '3L4KeuZsCf5PHkXPvvvCQG'
             }
@@ -39,7 +39,7 @@ class RecosAPITestSuite(unittest.TestCase):
         self.assertIsNotNone(request)
         self.assertEqual(request,
         {
-            'size': '50',
+            'size': 50,
             'track': {
                 'id': '3L4KeuZsCf5PHkXPvvvCQG'
             }

--- a/test/unit_tests/api/schemas/test_response.py
+++ b/test/unit_tests/api/schemas/test_response.py
@@ -93,24 +93,57 @@ class ResponseBuilderTestSuite(unittest.TestCase):
                 },
                 {
                     "id": "3x7gMvCsL1SS6THGwB55Pm"
+                }
+            ],
+            "request": {
+                "size": 2,
+                "track": {
+                    "id": "123"
+                }
+            }
+        }
+        ok_response = response.OkResponseBuilder().build_response(recos_response=recos_dict, id='123', size=2)
+
+        self.assertEqual(expected_response, ok_response.response)
+        self.assertEqual(200, ok_response.response_code)
+    
+    def test_should_properly_build_200_response_with_input_as_neighbor(self):
+        recos_dict = {
+            "neighbor": [
+                {
+                    "id": "123",
+                    "distance": 0.0
+                },
+                {
+                    "id": "3x7gMvCsL1SS6THGwB55Pm",
+                    "distance": 2.0
+                },
+                {
+                    "id": "7sLQGgXFs4LaGAaDErPwOl",
+                    "distance": 5.0
+                }
+            ]
+        }
+        expected_response = {
+            "recos": [
+                {
+                    "id": "3x7gMvCsL1SS6THGwB55Pm"
                 },
                 {
                     "id": "7sLQGgXFs4LaGAaDErPwOl"
                 }
             ],
             "request": {
-                "size": 5,
+                "size": 2,
                 "track": {
                     "id": "123"
                 }
             }
         }
-        ok_response = response.OkResponseBuilder().build_response(recos_response=recos_dict, id='123', size=5)
+        ok_response = response.OkResponseBuilder().build_response(recos_response=recos_dict, id='123', size=2)
 
         self.assertEqual(expected_response, ok_response.response)
         self.assertEqual(200, ok_response.response_code)
-
-        
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Related Issue
<!-- Related issues go here -->
- #68 

## Description
- For the `/v1/reco/{id}` resource, the `recos` dictionary is expected to return recommended Spotify tracks that do not contain the input track. This issue is reproduced whenever the input track exists as a valid candidate in our ANN index: since our model performs an approximate nearest neighbors search, an input song that exists in our ANN index will map onto itself in our feature space and be served as the first recommendation. This pull request changes the unary gRPC call to return N+1 recommendations so that N unique recommendations will always be returned.
  - In order to test these changes, unit test and integration test changes were introduced in 6d1cdaba07194a31d2efbe9c08fd7872153e6bed. The screenshot below shows the same request from #68 in order to verify that the bug is no longer reproducible for calling clients.
  - This pull request also introduces a backwards-incompatible change at the contract level: the field `size` is now returned as an integer instead of a string, which should have been the initially chosen type.

## Tests Included
- [X] Unit tests
- [X]  Integration tests
- [X] Environment tests
- [X] Regression tests
- [ ] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
<img width="1680" alt="Screen Shot 2023-01-08 at 8 24 18 PM" src="https://user-images.githubusercontent.com/10148029/211241338-e19f847f-5619-46f2-87ef-440c15bb534e.png">
<img width="1680" alt="Screen Shot 2023-01-08 at 8 23 16 PM" src="https://user-images.githubusercontent.com/10148029/211241347-b5501a19-fbd2-4f4b-ba5a-c1acb098c46d.png">
