### PR TITLE
Configure Cloud Build CD pipeline to allow bypassing integration test phase #98

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -24,7 +24,7 @@ steps:
   args:
     - '-c'
     - |
-      if ["$_SKIP_TESTS" != "true"]; then
+      if [ "$_SKIP_TESTS" != "true" ]; then
         gcloud run --network=cloudbuild gcr.io/$PROJECT_ID/spotifind-integration-test
       fi
 # Build container image for deploy component in Kubeflow

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -24,7 +24,7 @@ steps:
   args:
     - '-c'
     - |
-      if ["$_SKIP_TESTS" == "true"]; then
+      if ["$_SKIP_TESTS" != "true"]; then
         gcloud run --network=cloudbuild gcr.io/$PROJECT_ID/spotifind-integration-test
       fi
 # Build container image for deploy component in Kubeflow

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,7 +20,13 @@ steps:
 # Deploy container image for integration tests
 - id: 'Deploy Docker image for spotifind API integration tests'
   name: 'gcr.io/cloud-builders/docker'
-  args: ['run', '--network=cloudbuild', 'gcr.io/${PROJECT_ID}/spotifind-integration-test']
+  entrypoint: bash
+  args:
+    - '-c'
+    - |
+      if ["$_SKIP_TESTS" == "true"]; then
+        gcloud run --network=cloudbuild gcr.io/$PROJECT_ID/spotifind-integration-test
+      fi
 # Build container image for deploy component in Kubeflow
 - id: 'Build Docker image for Kubeflow deploy component'
   name: 'gcr.io/cloud-builders/docker'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -25,7 +25,7 @@ steps:
     - '-c'
     - |
       if [ "$_SKIP_TESTS" != "true" ]; then
-        gcloud run --network=cloudbuild gcr.io/$PROJECT_ID/spotifind-integration-test
+        docker run --network=cloudbuild gcr.io/$PROJECT_ID/spotifind-integration-test
       fi
 # Build container image for deploy component in Kubeflow
 - id: 'Build Docker image for Kubeflow deploy component'

--- a/deployment.yml
+++ b/deployment.yml
@@ -56,7 +56,7 @@ spec:
         - name: SECRET_VERSION_ID
           value: "latest"
         - name: ENVIRONMENT
-          value: "development"
+          value: "staging"
       # Sidecar container for warmups. We take this example directly from the expedia group documentation
       # https://opensource.expediagroup.com/mittens/docs/installation/running#run-as-a-sidecar-on-kubernetes
       - name: mittens

--- a/deployment.yml
+++ b/deployment.yml
@@ -56,7 +56,7 @@ spec:
         - name: SECRET_VERSION_ID
           value: "latest"
         - name: ENVIRONMENT
-          value: "staging"
+          value: "development"
       # Sidecar container for warmups. We take this example directly from the expedia group documentation
       # https://opensource.expediagroup.com/mittens/docs/installation/running#run-as-a-sidecar-on-kubernetes
       - name: mittens


### PR DESCRIPTION
## Related Issue
<!-- Related issues go here -->
- #98 

## Description
- Our Cloud Build pipeline blocks CD pipeline runs unless the matching engine ANN service is also deployed, since integration tests will otherwise fail. For development-related purposes, this pull request is created in order to configure a Cloud Build CD pipeline that bypasses the integration test phase.
  - Cloud Build currently does not allow for conditional phases on our CD pipeline. As an alternative, we decided to configure the [entrypoint](https://cloud.google.com/build/docs/build-config-file-schema#entrypoint) for the integration test phase to use bash. This allows us to conditionally run the docker container used for integration testing, based on the substitution variable `_SKIP_TESTS`.
  - To test these changes, a new Cloud Build pipeline was created, which allows for manual runs on demand. The screenshots below show the `_SKIP_TESTS` substitution variable running with both states (note that it will fail when integration tests actually run, since our gRPC service is currently not deployed).
<!-- Brief but accurate description for issues and solution proposed -->

## Tests Included
- [ ] Unit tests
- [ ]  Integration tests
- [X] Environment tests
- [ ] Regression tests
- [ ] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
<img width="1680" alt="Screen Shot 2023-01-12 at 1 30 28 AM" src="https://user-images.githubusercontent.com/10148029/212031524-ed99e831-006e-46fc-8d88-e6b9ab8c6100.png">
<img width="1680" alt="Screen Shot 2023-01-12 at 1 20 52 AM" src="https://user-images.githubusercontent.com/10148029/212031548-f11c7949-2330-443a-9cf7-9d3acb4aee23.png">
