### PR TITLE
Add connect and read timeouts for Spotify REST API clients

### DIFF
--- a/src/api/clients/spotify_client/client.py
+++ b/src/api/clients/spotify_client/client.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from ..spotify_auth_client.client import SpotifyAuthClient
 from ..logging_client.client import LoggingClient
+from ...config.config_facade import ConfigFacade
 import requests
 
 class Client(ABC):
@@ -13,12 +14,13 @@ class Client(ABC):
         pass
 
 class SpotifyClient(Client):
-    def __init__(self, auth_client: SpotifyAuthClient, logging_client: LoggingClient):
+    def __init__(self, auth_client: SpotifyAuthClient, logging_client: LoggingClient, config_facade: ConfigFacade):
         self._hostname = 'https://api.spotify.com'
         self._v1_tracks_path = '/v1/tracks/'
         self._v1_audio_features_path = '/v1/audio-features/'
         self._auth_client = auth_client
         self.logger = logging_client.get_logger(self.__class__.__name__)
+        self._config_facade = config_facade
 
     def v1_tracks(self, id, **kwargs) -> dict:
         batch = self.logger.batch()
@@ -41,7 +43,7 @@ class SpotifyClient(Client):
             'Authorization': bearer_token
         }
 
-        response = requests.get(endpoint, headers=headers)
+        response = requests.get(endpoint, headers=headers, timeout=self.get_timeouts())
         batch.log('status={}'.format(response.status_code), severity='NOTICE')
         response.raise_for_status()
         response_json = response.json()
@@ -63,7 +65,7 @@ class SpotifyClient(Client):
             'Authorization': bearer_token
         }
 
-        response = requests.get(endpoint, headers=headers)
+        response = requests.get(endpoint, headers=headers, timeout=self.get_timeouts())
         batch.log('status={}'.format(response.status_code), severity='NOTICE')
         response.raise_for_status()
         response_json = response.json()
@@ -71,6 +73,13 @@ class SpotifyClient(Client):
         batch.commit()
 
         return response_json
+    
+    def get_timeouts(self) -> tuple:
+        spotify_client_config = self._config_facade.get_spotify_client_config()
+        read_timeout = spotify_client_config['READ_TIMEOUT']
+        connect_timeout = spotify_client_config['CONNECT_TIMEOUT']
+
+        return (connect_timeout, read_timeout)
     
     def get_bearer_token(self) -> str:
         bearer_token_json = self._auth_client.get_bearer_token()

--- a/src/api/config/config_facade.py
+++ b/src/api/config/config_facade.py
@@ -6,9 +6,17 @@ class ConfigFacade():
         with app.app_context():
             self.environment = flask.current_app.config['ENVIRONMENT']
             self.match_service_enabled = flask.current_app.config['MATCH_SERVICE_ENABLED']
+            self.spotify_auth_client_config = flask.current_app.config['SPOTIFY_AUTH_CLIENT_CONFIG']
+            self.spotify_client_config = flask.current_app.config['SPOTIFY_CLIENT_CONFIG']
     
     def get_environment(self) -> str:
         return self.environment
     
     def is_match_service_enabled(self) -> bool:
         return self.match_service_enabled or False
+    
+    def get_spotify_auth_client_config(self) -> bool:
+        return self.spotify_auth_client_config or {}
+    
+    def get_spotify_client_config(self) -> bool:
+        return self.spotify_client_config or {}

--- a/src/api/config/default.json
+++ b/src/api/config/default.json
@@ -1,4 +1,12 @@
 {
     "ENVIRONMENT": "development",
-    "MATCH_SERVICE_ENABLED": false
+    "MATCH_SERVICE_ENABLED": false,
+    "SPOTIFY_AUTH_CLIENT_CONFIG": {
+        "CONNECT_TIMEOUT": 0.500,
+        "READ_TIMEOUT": 1.000
+    },
+    "SPOTIFY_CLIENT_CONFIG": {
+        "CONNECT_TIMEOUT": 0.500,
+        "READ_TIMEOUT": 0.500
+    }
 }

--- a/src/api/routes/reco.py
+++ b/src/api/routes/reco.py
@@ -20,8 +20,8 @@ print('Environment: {}'.format(config_facade.get_environment()))
 print('Is match service enabled: {}'.format(config_facade.is_match_service_enabled()))
 
 logging_client = LoggingClient()
-spotify_auth_client = SpotifyAuthClient(logging_client=logging_client)
-spotify_client = SpotifyClient(auth_client=spotify_auth_client, logging_client=logging_client)
+spotify_auth_client = SpotifyAuthClient(logging_client=logging_client, config_facade=config_facade)
+spotify_client = SpotifyClient(auth_client=spotify_auth_client, logging_client=logging_client, config_facade=config_facade)
 client_aggregator = ClientAggregator(config_facade=config_facade, mock_match_service_client=MockMatchServiceClient, match_service_client=MatchServiceClient)
 reco_adapter = V1RecoAdapter(spotify_client=spotify_client, logging_client=logging_client, client_aggregator=client_aggregator, response_builder_factory=response_builder_factory)
 

--- a/test/integration_tests/api/clients/spotify_auth_client/test_client.py
+++ b/test/integration_tests/api/clients/spotify_auth_client/test_client.py
@@ -1,13 +1,28 @@
 import unittest
+import flask
 from unittest.mock import Mock
 from src.api.clients.spotify_auth_client.client import SpotifyAuthClient
 from src.api.clients.logging_client.client import LoggingClient
+from src.api.config.config_facade import ConfigFacade
 from requests import HTTPError
 
 class SpotifyClientTestSuite(unittest.TestCase):
     def setUp(self) -> None:
         logging_client = LoggingClient()
-        self.auth_client = SpotifyAuthClient(logging_client=logging_client)
+        flask_app = flask.Flask(__name__)
+        flask_app.config['MATCH_SERVICE_ENABLED'] = True
+        flask_app.config['ENVIRONMENT'] = 'staging'
+        flask_app.config['SPOTIFY_AUTH_CLIENT_CONFIG'] = {
+            "CONNECT_TIMEOUT": 0.500,
+            "READ_TIMEOUT": 1.000
+        }
+        flask_app.config['SPOTIFY_CLIENT_CONFIG'] = {
+            "CONNECT_TIMEOUT": 0.500,
+            "READ_TIMEOUT": 1.000
+        }
+        with flask_app.app_context():
+            config_facade = ConfigFacade()
+            self.auth_client = SpotifyAuthClient(logging_client=logging_client, config_facade=config_facade)
     
     def test_should_return_bearer_token_for_valid_basic_authorization(self) -> None:
         bearer_token_dict = self.auth_client.get_bearer_token()

--- a/test/unit_tests/api/clients/spotify_auth_client/test_client.py
+++ b/test/unit_tests/api/clients/spotify_auth_client/test_client.py
@@ -16,7 +16,13 @@ class SpotifyAuthClientTestSuite(unittest.TestCase):
     def setUp(self) -> None:
         logging_client = Mock()
         logging_client.get_logger.return_value = Mock()
-        self._spotify_auth_client = spotify_auth_client.SpotifyAuthClient(logging_client)
+        
+        config_facade = Mock()
+        config_facade.get_spotify_auth_client_config.return_value = {
+            'CONNECT_TIMEOUT': 0.500,
+            'READ_TIMEOUT': 1.000
+        }
+        self._spotify_auth_client = spotify_auth_client.SpotifyAuthClient(logging_client, config_facade)
         self._response = requests.Response()
     
     def test_should_raise_error_for_4xx_response(self):

--- a/test/unit_tests/api/clients/spotify_client/test_client.py
+++ b/test/unit_tests/api/clients/spotify_client/test_client.py
@@ -16,7 +16,12 @@ class SpotifyClientTestSuite(unittest.TestCase):
     def setUp(self) -> None:
         logging_client = Mock()
         auth_client = Mock()
-        self._spotify_client = spotify_client.SpotifyClient(auth_client, logging_client)
+        config_facade = Mock()
+        config_facade.get_spotify_client_config.return_value = {
+            'CONNECT_TIMEOUT': 0.500,
+            'READ_TIMEOUT': 0.500
+        }
+        self._spotify_client = spotify_client.SpotifyClient(auth_client, logging_client, config_facade)
         self._response = requests.Response()
     
     def test_should_raise_error_for_4xx_response_on_v1_tracks(self):
@@ -73,7 +78,12 @@ class SpotifyClientTestSuite(unittest.TestCase):
             'access_token': 'token'
         }
         logging_client = Mock()
-        self._spotify_client = spotify_client.SpotifyClient(auth_client, logging_client)
+        config_facade = Mock()
+        config_facade.get_spotify_client_config.return_value = {
+            'CONNECT_TIMEOUT': 0.500,
+            'READ_TIMEOUT': 0.500
+        }
+        self._spotify_client = spotify_client.SpotifyClient(auth_client, logging_client, config_facade)
 
         bearer_token = self._spotify_client.get_bearer_token()
 

--- a/test/unit_tests/api/config/test_config_facade.py
+++ b/test/unit_tests/api/config/test_config_facade.py
@@ -7,6 +7,14 @@ class ConfigFacadeTestSuite(unittest.TestCase):
         flask_app = flask.Flask(__name__)
         flask_app.config['MATCH_SERVICE_ENABLED'] = True
         flask_app.config['ENVIRONMENT'] = 'development'
+        flask_app.config['SPOTIFY_AUTH_CLIENT_CONFIG'] = {
+            "CONNECT_TIMEOUT": 0.500,
+            "READ_TIMEOUT": 1.000
+        }
+        flask_app.config['SPOTIFY_CLIENT_CONFIG'] = {
+            "CONNECT_TIMEOUT": 0.500,
+            "READ_TIMEOUT": 1.000
+        }
         with flask_app.app_context():
             self.config_facade = ConfigFacade()
 
@@ -15,3 +23,17 @@ class ConfigFacadeTestSuite(unittest.TestCase):
 
     def test_should_return_if_match_service_client_enabled(self) -> None:
         self.assertTrue(self.config_facade.is_match_service_enabled())
+    
+    def test_should_return_spotify_auth_client_config(self) -> None:
+        spotify_auth_client_config = self.config_facade.get_spotify_auth_client_config()
+
+        self.assertIsNotNone(spotify_auth_client_config)
+        self.assertEqual(0.500, spotify_auth_client_config["CONNECT_TIMEOUT"])
+        self.assertEqual(1.000, spotify_auth_client_config["READ_TIMEOUT"])
+    
+    def test_should_return_spotify_auth_client_config(self) -> None:
+        spotify_client_config = self.config_facade.get_spotify_client_config()
+
+        self.assertIsNotNone(spotify_client_config)
+        self.assertEqual(0.500, spotify_client_config["CONNECT_TIMEOUT"])
+        self.assertEqual(1.000, spotify_client_config["READ_TIMEOUT"])


### PR DESCRIPTION
## Related Issue
- #100 
<!-- Related issues go here -->

## Description
- We currently do not have connect or read timeouts in place for any service clients, which makes our web service prone to hanging indefinitely. This pull request is created in order to add appropriate connect and read timeouts to all REST service clients.
  - Our strategy adopts the same config strategy in #49. Specifically, for each Spotify REST API client, float values `CONNECT_TIMEOUT` and `READ_TIMEOUT` were defined in the default config. Since the requests module supports [connect and read timeouts](https://requests.readthedocs.io/en/latest/api/#requests.request), these values were propagated to the relevant clients in code.
    - Note that the values for connect and read timeout were chosen empirically based on observations during development. In the future, we can consider doing load tests on each API to determine how to best set these timeout values.
<!-- Brief but accurate description for issues and solution proposed -->

## Tests Included
- [X] Unit tests
- [ ]  Integration tests
- [X] Environment tests
- [X] Regression tests
- [ ] Smoke tests

## Screenshots
<img width="1680" alt="Screen Shot 2023-01-13 at 1 28 12 AM" src="https://user-images.githubusercontent.com/10148029/212286659-96d8c6de-7957-4b78-ac96-89495dd4ae14.png">

<!-- Optional if screenshots provide clarity/context -->
