### PR TITLE
Add memory and CPU requests and limits for `spotifind` container

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -45,6 +45,7 @@ steps:
   - --image=gcr.io/${PROJECT_ID}/spotifind
   - --location=${_CLOUDSDK_COMPUTE_ZONE}
   - --cluster=${_CLOUDSDK_CONTAINER_CLUSTER}
+  - --timeout=${_GKE_DEPLOY_TIMEOUT}
 images:
 - gcr.io/${PROJECT_ID}/spotifind
 - gcr.io/${PROJECT_ID}/spotifind-integration-test

--- a/deployment.yml
+++ b/deployment.yml
@@ -30,20 +30,27 @@ spec:
       - name: spotifind-app
         image: gcr.io/spotifind-api/spotifind:latest
         imagePullPolicy: Always
+        resources:
+          limits:
+            memory: 128Mi
+            cpu: 75m
+          requests:
+            memory: 64Mi
+            cpu: 50m
         ports:
         - containerPort: 5000
         livenessProbe:
           httpGet:
             path: /health
             port: 5000
-          initialDelaySeconds: 5
-          periodSeconds: 5
+          initialDelaySeconds: 30
+          periodSeconds: 30
         readinessProbe:
           httpGet:
             path: /health
             port: 5000
-          initialDelaySeconds: 5
-          periodSeconds: 5
+          initialDelaySeconds: 150
+          periodSeconds: 30
         env:
         - name: PROJECT_ID
           value: "841506577075"
@@ -63,14 +70,14 @@ spec:
         image: expediagroup/mittens:latest
         resources:
           limits:
-            memory: 50Mi
-            cpu: 50m
+            memory: 32Mi
+            cpu: 5m
           requests:
-            memory: 50Mi
-            cpu: 50m
+            memory: 32Mi
+            cpu: 5m
         args:
         - "--concurrency=1"
-        - "--max-readiness-wait-seconds=60"
+        - "--max-readiness-wait-seconds=300"
         - "--max-warmup-seconds=30"
         - "--fail-readiness=true"
         - "--file-probe-enabled=false"


### PR DESCRIPTION
## Related Issue
<!-- Related issues go here -->
- #104 

## Description
- We are interested in scaling down the virtual machines used for our workloads in GKE from `e2-medium` to `e2-small` instances. By doing so, monthly billing on GCP is reduced which means we are more likely to run this web service outside of development. This pull request is created in order to manage pod-level resources for the `spotifind` container.
  - In order to choose [request and limit values](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) for CPU and memory on our main container, we first looked at the virtual hardware specification for the [E2 machine types](https://cloud.google.com/compute/vm-instance-pricing#e2_sharedcore_machine_types). `e2-small` machine types only allow for 250 mCPUs and 2 GBs of memory. Our workload in GKE does not contain the only pods we need to consider, since our nodes host pods from services in other namespaces. Below is an example namespace called `kube-system` which is included on every cluster in GKE.
  - <img width="720" alt="Screen Shot 2023-01-16 at 11 48 41 PM" src="https://user-images.githubusercontent.com/10148029/212839544-c9973e6f-7be9-4e80-be75-1a1584aea0b4.png">
  - Since we are only allowed to provision 250 mCPUs and 2 GBs of memory on `e2-small` instances, we took into account the existing resource allocation from other namespaces for all nodes. Ultimately our workload performed best with the values defined in 87a787866d7be5ea4f44cb70615949c21976a712.
  - When scaling down the machine type, pods provisioned during deployment from our workload had readiness-state issues. In order to accommodate this, the `initialDelaySeconds` for the readiness probe on our main container was bumped to 150 seconds.
- Note that we also coupled changes to the Cloud Build pipeline from 427b1a21420dbdfc95d00abf147844c4be2f78df into this pull request. This parameterizes the timeout value on GKE deployments in order to accommodate the increased delay of our readiness probes.

<!-- Brief but accurate description for issues and solution proposed -->

## Tests Included
- [ ] Unit tests
- [ ]  Integration tests
- [X] Environment tests
- [ ] Regression tests
- [ ] Smoke tests

## Screenshots
<img width="1680" alt="Screen Shot 2023-01-16 at 11 54 11 PM" src="https://user-images.githubusercontent.com/10148029/212840411-3be08ac0-a986-4825-a3fd-50bfa385b20c.png">


<!-- Optional if screenshots provide clarity/context -->
