### PR TITLE
REST client implementation for `POST::/v1/users/{user_id}/playlists` API

### DIFF
--- a/test/unit_tests/api/clients/spotify_client/test_client.py
+++ b/test/unit_tests/api/clients/spotify_client/test_client.py
@@ -71,6 +71,27 @@ class SpotifyClientTestSuite(unittest.TestCase):
         response = self._spotify_client.v1_audio_features('id')
 
         self.assertEqual({}, response)
+    
+    def test_should_return_json_for_2xx_response_on_v1_create_playlist(self):
+        self._response.status_code = 200
+        requests.post = Mock(return_value=self._response)
+        requests.Response.json = Mock(return_value={})
+        
+        response = self._spotify_client.v1_create_playlist('user_id', 'user_token')
+
+        self.assertEqual({}, response)
+    
+    def test_should_raise_error_for_4xx_response_on_v1_create_playlist(self):
+        self._response.status_code = 400
+        requests.post = Mock(return_value=self._response)
+
+        self.assertRaises(requests.HTTPError, self._spotify_client.v1_create_playlist, 'user_id', 'user_token')
+    
+    def test_should_raise_error_for_5xx_response_on_v1_create_playlist(self):
+        self._response.status_code = 500
+        requests.post = Mock(return_value=self._response)
+
+        self.assertRaises(requests.HTTPError, self._spotify_client.v1_create_playlist, 'user_id', 'user_token')
 
     def test_should_return_correct_authorization_header(self):
         auth_client = Mock()


### PR DESCRIPTION
## Related Issue
- #95 
<!-- Related issues go here -->

## Description
- The changes proposed in #92 for the `POST::/v1/playlist/{id*}` API require that an additional service client is created for Spotify's `POST::/v1/users/{user_id}/playlists` API. This pull request is created in order to implement a REST client for Spotify's [create playlist](https://developer.spotify.com/console/post-playlists/) API.
  - Note that [client credentials](https://developer.spotify.com/documentation/general/guides/authorization/client-credentials/) cannot be used here for authorization, since this API requires a Bearer token with [playlist-modify-public](https://developer.spotify.com/documentation/general/guides/authorization/scopes/#playlist-modify-public), [playlist-modify-private](https://developer.spotify.com/documentation/general/guides/authorization/scopes/#playlist-modify-private) scopes. Since generating a Bearer token of these scopes requires user involvement, we will accept this as technical debt and try to investigate strategies to add integration tests for this REST client in the future.
  - In order to test these changes, unit tests were added in 1d230a89dc876db12371e0662d6546076159578a. Since integration tests could not be used to verify successful API calls for our new client, local environment tests were performed on minikube with a dummy URI (`POST::/v1/playlist/{id*}`) that exposes the response for this client. The screenshot below shows an example 2xx response returned after successful playlist creation.

## Tests Included
- [X] Unit tests
- [ ]  Integration tests
- [X] Environment tests
- [ ] Regression tests
- [ ] Smoke tests

## Screenshots
<img width="1680" alt="Screen Shot 2023-01-17 at 10 45 34 PM" src="https://user-images.githubusercontent.com/10148029/213104193-311d2462-cb53-479c-b728-b82a3a5fc6d4.png">

<!-- Optional if screenshots provide clarity/context -->
