### PR TITLE
REST client implementation for `POST::/v1/playlists/{playlist_id}/tracks` API

### DIFF
--- a/src/api/clients/spotify_client/client.py
+++ b/src/api/clients/spotify_client/client.py
@@ -120,7 +120,7 @@ class SpotifyClient(Client):
 
         playlist_resource = self._v1_playlist_tracks_path.format(playlist_id)
         url = '{}{}'.format(self._hostname, playlist_resource)
-        
+
         batch.log('Making POST call to {}'.format(playlist_resource), severity='INFO')
         batch.log('playlist_id={}'.format(playlist_id), severity='INFO')
 
@@ -133,7 +133,7 @@ class SpotifyClient(Client):
             'Authorization': user_token
         }
 
-        response = requests.post(url=url, json=payload, headers=headers)
+        response = requests.post(url=url, json=json.loads(json.dumps(payload)), headers=headers)
         batch.log('status={}'.format(response.status_code), severity='NOTICE')
         response.raise_for_status()
         response_json = response.json()

--- a/src/api/clients/spotify_client/client.py
+++ b/src/api/clients/spotify_client/client.py
@@ -18,12 +18,17 @@ class Client(ABC):
     def v1_create_playlist(self, user_id, user_token, name='Spotifind playlist', description='https://github.com/NoahT/spotifind-flask-api', is_public=True) -> dict:
         pass
 
+    @abstractmethod
+    def v1_playlist_tracks(self, playlist_id, uris, user_token) -> dict:
+        pass
+
 class SpotifyClient(Client):
     def __init__(self, auth_client: SpotifyAuthClient, logging_client: LoggingClient, config_facade: ConfigFacade):
         self._hostname = 'https://api.spotify.com'
         self._v1_tracks_path = '/v1/tracks/'
         self._v1_audio_features_path = '/v1/audio-features/'
         self._v1_create_playlist_path = '/v1/users/{}/playlists'
+        self._v1_playlist_tracks_path = '/v1/playlists/{}/tracks'
         self._auth_client = auth_client
         self._logger = logging_client.get_logger(self.__class__.__name__)
         self._config_facade = config_facade
@@ -83,18 +88,19 @@ class SpotifyClient(Client):
     def v1_create_playlist(self, user_id, user_token, name='Spotifind playlist', description='https://github.com/NoahT/spotifind-flask-api', is_public=True) -> dict:
         batch = self._logger.batch()
 
-        batch.log('Making POST call to {}'.format(self._v1_create_playlist_path), severity='INFO')
-        batch.log('user_id={}'.format(user_id), severity='INFO')
-        
         playlist_resource = self._v1_create_playlist_path.format(user_id)
         url = '{}{}'.format(self._hostname, playlist_resource)
+
+        batch.log('Making POST call to {}'.format(playlist_resource), severity='INFO')
+        batch.log('user_id={}'.format(user_id), severity='INFO')
+        
         
         payload = {
             'name': name,
             'description': description,
             'public': is_public
         }
-        batch.log('payload={}'.format(json.dumps(payload)))
+        batch.log('payload={}'.format(json.dumps(payload)), severity='INFO')
 
         headers = {
             'Authorization': user_token
@@ -105,6 +111,33 @@ class SpotifyClient(Client):
         response.raise_for_status()
         response_json = response.json()
         batch.log('response={}'.format(response_json), severity='INFO')
+        batch.commit()
+
+        return response_json
+    
+    def v1_playlist_tracks(self, playlist_id, uris, user_token) -> dict:
+        batch = self._logger.batch()
+
+        playlist_resource = self._v1_playlist_tracks_path.format(playlist_id)
+        url = '{}{}'.format(self._hostname, playlist_resource)
+        
+        batch.log('Making POST call to {}'.format(playlist_resource), severity='INFO')
+        batch.log('playlist_id={}'.format(playlist_id), severity='INFO')
+
+        payload = {
+            'uris': ['spotify:track:{}'.format(uri) for uri in uris]
+        }
+        batch.log('payload={}'.format(json.dumps(payload)), severity='INFO')
+        
+        headers = {
+            'Authorization': user_token
+        }
+
+        response = requests.post(url=url, json=payload, headers=headers)
+        batch.log('status={}'.format(response.status_code), severity='NOTICE')
+        response.raise_for_status()
+        response_json = response.json()
+        batch.log('response={}'.format(json.dumps(response_json)), severity='INFO')
         batch.commit()
 
         return response_json

--- a/test/unit_tests/api/clients/spotify_client/test_client.py
+++ b/test/unit_tests/api/clients/spotify_client/test_client.py
@@ -92,6 +92,27 @@ class SpotifyClientTestSuite(unittest.TestCase):
         requests.post = Mock(return_value=self._response)
 
         self.assertRaises(requests.HTTPError, self._spotify_client.v1_create_playlist, 'user_id', 'user_token')
+    
+    def test_should_return_json_for_2xx_response_on_v1_playlist_tracks(self):
+        self._response.status_code = 200
+        requests.post = Mock(return_value=self._response)
+        requests.Response.json = Mock(return_value={})
+
+        response = self._spotify_client.v1_playlist_tracks('playlist_id', ['uri1', 'uri2'], 'user_token')
+        
+        self.assertEqual({}, response)
+    
+    def test_should_raise_error_for_4xx_response_on_v1_playlist_tracks(self):
+        self._response.status_code = 400
+        requests.post = Mock(return_value=self._response)
+
+        self.assertRaises(requests.HTTPError, self._spotify_client.v1_playlist_tracks, 'playlist_id', ['uri1', 'uri2'], 'user_token')
+    
+    def test_should_raise_error_for_5xx_response_on_v1_playlist_tracks(self):
+        self._response.status_code = 500
+        requests.post = Mock(return_value=self._response)
+        
+        self.assertRaises(requests.HTTPError, self._spotify_client.v1_playlist_tracks, 'playlist_id', ['uri1', 'uri2'], 'user_token')
 
     def test_should_return_correct_authorization_header(self):
         auth_client = Mock()


### PR DESCRIPTION
## Related Issue
- #96 
<!-- Related issues go here -->

## Description
- Based on the design changes introduced in #92, we are primarily interested in adding a service client for Spotify's `POST::/v1/playlists/{playlist_id}/tracks` API. This pull request introduces the associated service client implementation.
  - Note that these changes adopt a very similar strategy to #106. Since this API also requires a Bearer token with scopes [playlist-modify-public](https://developer.spotify.com/documentation/general/guides/authorization/scopes/#playlist-modify-public) and [playlist-modify-private](https://developer.spotify.com/documentation/general/guides/authorization/scopes/#playlist-modify-private), they require end user involvement and cannot be done independently on the service side. We consequently cannot adopt integration tests for this service client as well and acknowledge this as technical debt to try to resolve in the future.
  - Since integration tests cannot be used to verify this service client beyond unit tests, in order to test these changes a dummy resource was created for local environment tests. The screenshot below shows both the `POST::/v1/users/{user_id}/playlists` and `POST::/v1/playlists/{playlist_id}/tracks` making sequential service calls to populate a playlist on a Kubernetes cluster in minikube.
<!-- Brief but accurate description for issues and solution proposed -->

## Tests Included
- [X] Unit tests
- [ ]  Integration tests
- [X] Environment tests
- [ ] Regression tests
- [ ] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
<img width="1680" alt="Screen Shot 2023-01-19 at 12 18 06 AM" src="https://user-images.githubusercontent.com/10148029/213391939-5541b205-76fc-4f79-9eec-6ec5d3226526.png">
<img width="1680" alt="Screen Shot 2023-01-19 at 12 27 27 AM" src="https://user-images.githubusercontent.com/10148029/213391861-c7304f13-f58c-4e03-b078-03b210ff30cd.png">
