### PR TITLE
Decoupled environment-based config from Flask application context

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,20 +1,10 @@
 from flask import Flask, Blueprint
 from .routes.healthcheck import healthcheck
-from flasgger import Swagger
-import json
-import os
-
-CONFIG_PATH = './config/'
-def load_config(app: Flask, config_env: str):
-    config_file = '{}{}.json'.format(CONFIG_PATH, config_env)
-    print('Config file: {}'.format(config_file))
-    app.config.from_file(config_file, load=json.load)
 
 def load_blueprints(app: Flask):
     from .routes.reco import reco
 
     v1 = Blueprint('name', __name__)
-    swagger = Swagger(app)
 
     v1.register_blueprint(reco, url_prefix='/reco')
     app.register_blueprint(v1, url_prefix='/v1')
@@ -24,9 +14,5 @@ def load_blueprints(app: Flask):
 
 flask_app = Flask(__name__)
 flask_app.app_context().push()
-
-load_config(flask_app, 'default')
-config_env = os.environ['ENVIRONMENT']
-load_config(flask_app, config_env)
 
 load_blueprints(flask_app)

--- a/src/api/config/config_facade.py
+++ b/src/api/config/config_facade.py
@@ -1,13 +1,28 @@
-import flask
+import json
+import os
+
+CONFIG_PATH = './config/'
+def load_config(config_env: str):
+    config_file_path = '{}{}.json'.format(CONFIG_PATH, config_env)
+    print('Config file: {}'.format(config_file_path))
+    
+    config = {}
+    with open(config_file_path, 'r', encoding='utf-8') as file:
+        config = json.loads(file.read())
+    
+    return config
 
 class ConfigFacade():
     def __init__(self) -> None:
-        app = flask.current_app
-        with app.app_context():
-            self.environment = flask.current_app.config['ENVIRONMENT']
-            self.match_service_enabled = flask.current_app.config['MATCH_SERVICE_ENABLED']
-            self.spotify_auth_client_config = flask.current_app.config['SPOTIFY_AUTH_CLIENT_CONFIG']
-            self.spotify_client_config = flask.current_app.config['SPOTIFY_CLIENT_CONFIG']
+        config_default = load_config('default')
+        config_environment = load_config(os.environ['ENVIRONMENT'])
+        # https://peps.python.org/pep-0448/
+        config = {**config_default, **config_environment}
+        
+        self.environment = config['ENVIRONMENT']
+        self.match_service_enabled = config['MATCH_SERVICE_ENABLED']
+        self.spotify_auth_client_config = config['SPOTIFY_AUTH_CLIENT_CONFIG']
+        self.spotify_client_config = config['SPOTIFY_CLIENT_CONFIG']
     
     def get_environment(self) -> str:
         return self.environment

--- a/test/unit_tests/api/config/test_config_facade.py
+++ b/test/unit_tests/api/config/test_config_facade.py
@@ -1,39 +1,44 @@
+import json
 import unittest
+from unittest.mock import mock_open, patch
 from src.api.config.config_facade import ConfigFacade
-import flask
+
+config = {
+    'ENVIRONMENT': 'development',
+    'MATCH_SERVICE_ENABLED': False,
+    'SPOTIFY_AUTH_CLIENT_CONFIG': {
+        'CONNECT_TIMEOUT': 0.500,
+        'READ_TIMEOUT': 1.000
+    },
+    'SPOTIFY_CLIENT_CONFIG': {
+        'CONNECT_TIMEOUT': 0.500,
+        'READ_TIMEOUT': 0.500
+    }
+}
+
 
 class ConfigFacadeTestSuite(unittest.TestCase):
-    def setUp(self) -> None:
-        flask_app = flask.Flask(__name__)
-        flask_app.config['MATCH_SERVICE_ENABLED'] = True
-        flask_app.config['ENVIRONMENT'] = 'development'
-        flask_app.config['SPOTIFY_AUTH_CLIENT_CONFIG'] = {
-            "CONNECT_TIMEOUT": 0.500,
-            "READ_TIMEOUT": 1.000
-        }
-        flask_app.config['SPOTIFY_CLIENT_CONFIG'] = {
-            "CONNECT_TIMEOUT": 0.500,
-            "READ_TIMEOUT": 1.000
-        }
-        with flask_app.app_context():
-            self.config_facade = ConfigFacade()
-
+    @patch('builtins.open', new_callable=mock_open, read_data=json.dumps(config))
+    @patch('os.environ', { 'ENVIRONMENT': 'development' })
+    def setUp(self, mock_file) -> None:
+        self.config_facade = ConfigFacade()
+    
     def test_should_return_environment_when_in_config(self) -> None:
         self.assertEqual('development', self.config_facade.get_environment())
 
     def test_should_return_if_match_service_client_enabled(self) -> None:
-        self.assertTrue(self.config_facade.is_match_service_enabled())
-    
+        self.assertFalse(self.config_facade.is_match_service_enabled())
+
     def test_should_return_spotify_auth_client_config(self) -> None:
         spotify_auth_client_config = self.config_facade.get_spotify_auth_client_config()
 
         self.assertIsNotNone(spotify_auth_client_config)
         self.assertEqual(0.500, spotify_auth_client_config["CONNECT_TIMEOUT"])
         self.assertEqual(1.000, spotify_auth_client_config["READ_TIMEOUT"])
-    
+
     def test_should_return_spotify_auth_client_config(self) -> None:
         spotify_client_config = self.config_facade.get_spotify_client_config()
 
         self.assertIsNotNone(spotify_client_config)
         self.assertEqual(0.500, spotify_client_config["CONNECT_TIMEOUT"])
-        self.assertEqual(1.000, spotify_client_config["READ_TIMEOUT"])
+        self.assertEqual(0.500, spotify_client_config["READ_TIMEOUT"])


### PR DESCRIPTION
## Related Issue
- #110 
<!-- Related issues go here -->

## Description
- Our environment-based config handling is currently bounded to the [Flask application context](https://flask.palletsprojects.com/en/2.2.x/appcontext/#the-application-context), and prone to breaking if used outside of this context (before first request) for initialization purposes. This pull request refactors the config handling strategy to no longer depend on the Flask application context.
  - In order to test these changes beyond unit tests, smoke tests were performed locally in order to verify that the correct config is being picked. The screenshots below show pod-level logs and a 200 status code on the `GET::/v1/reco/{id*}` API to indicate that the refactor in config handling does not impact the stability of new builds.
<!-- Brief but accurate description for issues and solution proposed -->

## Tests Included
- [X] Unit tests
- [ ]  Integration tests
- [ ] Environment tests
- [ ] Regression tests
- [X] Smoke tests

## Screenshots
<img width="1680" alt="Screen Shot 2023-01-20 at 12 41 02 AM" src="https://user-images.githubusercontent.com/10148029/213653069-f3ddcd53-72c1-4de4-871f-5007da8d7af0.png">
<img width="1680" alt="Screen Shot 2023-01-20 at 12 40 30 AM" src="https://user-images.githubusercontent.com/10148029/213653123-88e05b52-0abc-4e4c-97ce-d81fd089df51.png">

<!-- Optional if screenshots provide clarity/context -->
