### PR TITLE
Towards #109: Scaffolding for `POST::/v1/playlist/{id*}` API

### DIFF
--- a/src/api/routes/reco.py
+++ b/src/api/routes/reco.py
@@ -13,7 +13,7 @@ def id(id):
     size = request.args.get(key='size') or str(5)
 
     try:
-        response = reco_util.v1_reco_adapter.get_recos(id=id, size=size)
+        response = reco_util.v1_reco_controller.get_recos(id=id, size=size)
     except Exception:
         print(traceback.format_exc())
         response = schemas.response_builder_factory.get_builder(status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value).build_response(recos_response=None, id=id, size=size)

--- a/src/api/schemas/response.py
+++ b/src/api/schemas/response.py
@@ -1,7 +1,6 @@
 from abc import abstractmethod
 from http import HTTPStatus
 from abc import ABC
-from google.cloud.aiplatform.matching_engine.matching_engine_index_endpoint import MatchNeighbor
 
 class Response():
     def __init__(self, response: dict, response_code: int) -> None:

--- a/src/api/util/reco/__init__.py
+++ b/src/api/util/reco/__init__.py
@@ -3,5 +3,7 @@ import src.api.clients.spotify_client as spotify_client
 import src.api.clients.matching_engine_client as matching_engine_client
 import src.api.schemas as schemas
 from .reco_adapter import V1RecoAdapter
+from .reco_controller import V1RecoController
 
 v1_reco_adapter = V1RecoAdapter(spotify_client.spotify_client, logging_client.logging_client, matching_engine_client.match_client_aggregator, schemas.response_builder_factory)
+v1_reco_controller = V1RecoController(v1_reco_adapter, schemas.response_builder_factory)

--- a/src/api/util/reco/reco_adapter.py
+++ b/src/api/util/reco/reco_adapter.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 from http import HTTPStatus
 from urllib.error import HTTPError
-from requests import HTTPError as ClientHTTPError
 import src.api.clients.spotify_client.client as spotify_client
 import src.api.clients.logging_client.client as logging_client
 import src.api.clients.matching_engine_client.client_aggregator as client_aggregator
@@ -19,25 +18,27 @@ class V1RecoAdapter(RecoAdapter):
         self._match_service_client = None
         self.response_builder_factory = response_builder_factory
         # This is the feature space we chose for /v1/reco API. Note that these are the same features in Spotify /v1/audio-features API response
-        self.feature_mapping = ['danceability', 'energy', 'key', 'loudness', 'mode', 'speechiness', 'acousticness', 'instrumentalness', 'liveness', 'valence']
+        self.feature_mapping = [
+            'danceability',
+            'energy',
+            'key',
+            'loudness',
+            'mode',
+            'speechiness',
+            'acousticness',
+            'instrumentalness',
+            'liveness',
+            'valence'
+        ]
     
     def get_recos(self, id: str, size: str) -> response.Response:
-        recos_response = None
-        recos_dict = None
-        try:
-            self.validate_reco_size(size)
-            size = int(size)
+        self.validate_reco_size(size)
+        size = int(size)
 
-            audio_features = self.spotify_client.v1_audio_features(id=id)
-            track_embedding = self.get_embedding(audio_features=audio_features)
-            recos = self.match_service_client.get_match(match_request={'query': track_embedding, 'num_recos': (size + 1)})
-            recos_response = self.response_builder_factory.get_builder(status_code=HTTPStatus.OK.value).build_response(recos_response=recos[0], id=id, size=int(size))
-        except HTTPError as http_error:
-            print(http_error.__str__())
-            recos_response = self.response_builder_factory.get_builder(status_code=http_error.code).build_response(recos_response=recos_dict, id=id, size=size)
-        except ClientHTTPError as client_http_error:
-            print(client_http_error.__str__())
-            recos_response = self.response_builder_factory.get_builder(status_code=client_http_error.response.status_code).build_response(recos_response=recos_dict, id=id, size=size)
+        audio_features = self.spotify_client.v1_audio_features(id=id)
+        track_embedding = self.get_embedding(audio_features=audio_features)
+        recos = self.match_service_client.get_match(match_request={'query': track_embedding, 'num_recos': (size + 1)})
+        recos_response = self.response_builder_factory.get_builder(status_code=HTTPStatus.OK.value).build_response(recos_response=recos[0], id=id, size=int(size))
         
         return recos_response
     

--- a/src/api/util/reco/reco_controller.py
+++ b/src/api/util/reco/reco_controller.py
@@ -1,0 +1,29 @@
+from abc import ABC, abstractmethod
+from urllib.error import HTTPError
+from requests import HTTPError as ClientHTTPError
+import src.api.schemas.response as response
+from . import reco_adapter
+
+class RecoController(ABC):
+    @abstractmethod
+    def get_recos(self, id: str, size: int) -> response.Response:
+        pass
+
+class V1RecoController(RecoController):
+    def __init__(self, reco_adapter: reco_adapter.RecoAdapter, response_builder_factory: response.ResponseBuilderFactory) -> None:
+        self._reco_adapter = reco_adapter
+        self._response_builder_factory = response_builder_factory
+
+    def get_recos(self, id: str, size: int) -> response.Response:
+        recos_response = None
+        try:
+            recos_response = self._reco_adapter.get_recos(id, size)
+        except HTTPError as http_error:
+            print(http_error.__str__())
+            recos_response = self._response_builder_factory.get_builder(status_code=http_error.code).build_response(recos_response=None, id=id, size=size)
+        except ClientHTTPError as client_http_error:
+            print(client_http_error.__str__())
+            recos_response = self._response_builder_factory.get_builder(status_code=client_http_error.response.status_code).build_response(recos_response=None, id=id, size=size)
+        
+        return recos_response
+

--- a/test/unit_tests/api/util/reco/test_reco_adapter.py
+++ b/test/unit_tests/api/util/reco/test_reco_adapter.py
@@ -1,6 +1,7 @@
 from http import HTTPStatus
 from google.cloud.aiplatform.matching_engine.matching_engine_index_endpoint import MatchNeighbor
 from requests import HTTPError as ClientHTTPError, Response
+from urllib.error import HTTPError
 from unittest.mock import patch, Mock
 import src.api.util.reco.reco_adapter as reco_adapter
 import src.api.schemas.response as response
@@ -88,6 +89,15 @@ class V1RecoAdapterTestSuite(unittest.TestCase):
         response = self.reco_adapter.get_recos(id='id', size='1.1')
         
         self.assertEqual(400, response['status'])
+    
+    def test_should_raise_HTTPError_when__validating_invalid_reco_size_type(self) -> None:
+        self.assertRaises(HTTPError, self.reco_adapter.validate_reco_size, '1.1')
+
+    def test_should_raise_HTTPError_when_validating_invalid_reco_size_value(self) -> None:
+        self.assertRaises(HTTPError, self.reco_adapter.validate_reco_size, '0')
+
+    def test_should_not_raise_HTTPError_on_valid_reco_size(self) -> None:
+        self.reco_adapter.validate_reco_size('5')
 
     def test_should_create_correct_v1_track_embeddings(self) -> None:
         audio_features = {

--- a/test/unit_tests/api/util/reco/test_reco_controller.py
+++ b/test/unit_tests/api/util/reco/test_reco_controller.py
@@ -1,0 +1,70 @@
+import unittest
+from unittest.mock import patch, Mock
+from http import HTTPStatus
+from requests import HTTPError as ClientHTTPError
+import src.api.schemas.response as response
+import src.api.util.reco.reco_controller as reco_controller
+
+class V1RecoControllerTestSuite(unittest.TestCase):
+    @patch('src.api.schemas.response.ResponseBuilderFactory')
+    @patch('src.api.util.reco.reco_adapter.V1RecoAdapter')
+    def setUp(self, reco_adapter, response_builder_factory) -> None:
+        bad_request_response_builder = Mock(response.BadRequestResponseBuilder)
+        bad_request_response_builder.build_response.return_value = response.Response(None, 400)
+        not_found_response_builder = Mock(response.NotFoundResponseBuilder)
+        not_found_response_builder.build_response.return_value = response.Response(None, 404)
+        self.bad_request_response_builder = bad_request_response_builder
+        self.not_found_response_builder = not_found_response_builder
+        def response_builder_factory_side_effect(**kwargs):
+            response_builder = None
+            status_code = kwargs['status_code']
+            if status_code == HTTPStatus.NOT_FOUND.value:
+                response_builder = not_found_response_builder
+            else:
+                response_builder = bad_request_response_builder
+            
+            return response_builder
+        
+        response_builder_factory.get_builder.side_effect = response_builder_factory_side_effect
+        self._v1_reco_controller = reco_controller.V1RecoController(reco_adapter, response_builder_factory)
+    
+    def test_should_return_400_response_on_invalid_client_request(self) -> None:
+        def side_effect(id, size):
+            mock_response = Mock()
+            mock_response.status_code = 400
+            raise ClientHTTPError(response=mock_response)
+        
+        self._v1_reco_controller._reco_adapter.get_recos.side_effect = side_effect
+        reco_response = self._v1_reco_controller.get_recos('invalid', '5')
+        self.assertEqual(400, reco_response.response_code)
+    
+    def test_should_return_200_response_on_valid_client_request(self) -> None:
+        mock_response = response.Response(
+            {
+                'request': {
+                    'track': {
+                        'id': 'track_id'
+                    },
+                    'size': 5
+                },
+                'recos': [
+                    {
+                        'id': 'reco1'
+                    },
+                    {
+                        'id': 'reco2'
+                    },
+                    {
+                        'id': 'reco3'
+                    },
+                ]
+            },
+            200
+        )
+        self._v1_reco_controller._reco_adapter.get_recos.return_value = mock_response
+        
+        reco_response = self._v1_reco_controller.get_recos('track_id', '5')
+
+        self.assertEqual(mock_response.response_code, reco_response.response_code)
+        self.assertEqual(mock_response.response, reco_response.response)
+


### PR DESCRIPTION
## Related Issue
- #109 
<!-- Related issues go here -->

## Description
- Since REST API clients for the `POST::/v1/users/{user_id*}/playlists` and `POST::/v1/playlists/{playlist_id*}/tracks` APIs are now implemented, we are primarily interested in implementing the agreed-upon contract for the `POST::/v1/playlist/{id*}` API. This pull request is created in order to introduce changes _towards_ scaffolding for the `POST::/v1/playlist/{id*}` API.
  - This pull request is created towards the changes in #109, so we will not close this issue in this pull request. The adapter pattern introduced in #55 should only take complexity from massaging data between two backwards-incompatible interfaces. Since our adapter class also handles validation and error handling, this logic was decoupled in 7ebf818 and af10b19.

<!-- Brief but accurate description for issues and solution proposed -->

## Tests Included
- [X] Unit tests
- [ ]  Integration tests
- [ ] Environment tests
- [X] Regression tests
- [ ] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
<img width="1680" alt="Screen Shot 2023-01-28 at 5 48 30 PM" src="https://user-images.githubusercontent.com/10148029/215299909-5b1f9cc4-0b26-47be-b49f-ba8357897a14.png">
