### PR TITLE
Refactor response handling logic to accommodate response headers

### DIFF
--- a/src/api/schemas/__init__.py
+++ b/src/api/schemas/__init__.py
@@ -1,3 +1,20 @@
-from .response import ResponseBuilderFactory
+from .response import (
+    ResponseBuilderFactory,
+    BadRequestResponseBuilder,
+    UnauthorizedResponseBuilder,
+    ForbiddenResponseBuilder,
+    NotFoundResponseBuilder,
+    InternalServerErrorResponseBuilder,
+    OkResponseBuilder,
+    CreatedResponseBuilder
+)
 
-response_builder_factory = ResponseBuilderFactory()
+response_builder_factory = ResponseBuilderFactory(
+    bad_request_builder=BadRequestResponseBuilder(),
+    unauthorized_builder=UnauthorizedResponseBuilder(),
+    forbidden_builder=ForbiddenResponseBuilder(),
+    not_found_builder=NotFoundResponseBuilder(),
+    internal_server_error_builder=InternalServerErrorResponseBuilder(),
+    ok_builder=OkResponseBuilder(),
+    created_builder=CreatedResponseBuilder()
+)

--- a/src/api/schemas/response.py
+++ b/src/api/schemas/response.py
@@ -23,6 +23,30 @@ class BadRequestResponseBuilder(ResponseBuilder):
         }
         return Response(response=response, response_code=self._response_code)
 
+class UnauthorizedResponseBuilder(ResponseBuilder):
+    def __init__(self) -> None:
+        self._response_code = HTTPStatus.UNAUTHORIZED.value
+    
+    def build_response(self, recos_response: list, id: str, size: int) -> Response:
+        response = {
+            'message': 'Valid authentication credentials not provided.',
+            'status': self._response_code
+        }
+
+        return Response(response=response, response_code=self._response_code)
+
+class ForbiddenResponseBuilder(ResponseBuilder):
+    def __init__(self) -> None:
+        self._response_code = HTTPStatus.FORBIDDEN.value
+    
+    def build_response(self, recos_response: list, id: str, size: int) -> Response:
+        response = {
+            'message': 'Insufficient authentication credentials.',
+            'status': self._response_code
+        }
+
+        return Response(response=response, response_code=self._response_code)
+
 class NotFoundResponseBuilder(ResponseBuilder):
     def __init__(self) -> None:
         self._response_code = HTTPStatus.NOT_FOUND.value
@@ -44,6 +68,13 @@ class InternalServerErrorResponseBuilder(ResponseBuilder):
             'status': self._response_code
         }
         return Response(response=response, response_code=self._response_code)
+
+class CreatedResponseBuilder(ResponseBuilder):
+    def __init__(self) -> None:
+        self._response_code = HTTPStatus.CREATED.value
+    
+    def build_response(self, recos_response: list, id: str, size: int) -> Response:
+        return Response(response={}, response_code=self._response_code)
 
 class OkResponseBuilder(ResponseBuilder):
     def __init__(self) -> None:
@@ -70,22 +101,31 @@ class OkResponseBuilder(ResponseBuilder):
         return Response(response=response, response_code=self._response_code)
 
 class ResponseBuilderFactory():
-    def __init__(self, bad_request_builder=BadRequestResponseBuilder(), not_found_builder=NotFoundResponseBuilder(), internal_server_error_builder=InternalServerErrorResponseBuilder(), ok_builder=OkResponseBuilder()) -> None:
-        self._bad_request_builder = bad_request_builder
-        self._not_found_builder = not_found_builder
-        self._internal_server_error_builder = internal_server_error_builder
-        self._ok_builder = ok_builder
+    def __init__(self, **kwargs) -> None:
+        self._bad_request_builder = kwargs['bad_request_builder']
+        self._unauthorized_builder = kwargs['unauthorized_builder']
+        self._forbidden_builder = kwargs['forbidden_builder']
+        self._not_found_builder = kwargs['not_found_builder']
+        self._internal_server_error_builder = kwargs['internal_server_error_builder']
+        self._ok_builder = kwargs['ok_builder']
+        self._created_builder = kwargs['created_builder']
     
     def get_builder(self, status_code: int) -> ResponseBuilder:
         builder = None
         if status_code == HTTPStatus.BAD_REQUEST.value:
             builder = self._bad_request_builder
+        elif status_code == HTTPStatus.UNAUTHORIZED.value:
+            builder = self._unauthorized_builder
+        elif status_code == HTTPStatus.FORBIDDEN.value:
+            builder = self._forbidden_builder
         elif status_code == HTTPStatus.NOT_FOUND.value:
             builder = self._not_found_builder
         elif status_code == HTTPStatus.INTERNAL_SERVER_ERROR.value:
             builder = self._internal_server_error_builder
         elif status_code == HTTPStatus.OK.value:
             builder = self._ok_builder
+        elif status_code == HTTPStatus.CREATED.value:
+            builder = self._created_builder
         else:
             raise ValueError('Invalid or unsupported status code: {}'.format(status_code))
         return builder

--- a/src/api/util/reco/reco_adapter.py
+++ b/src/api/util/reco/reco_adapter.py
@@ -38,7 +38,7 @@ class V1RecoAdapter(RecoAdapter):
         audio_features = self.spotify_client.v1_audio_features(id=id)
         track_embedding = self.get_embedding(audio_features=audio_features)
         recos = self.match_service_client.get_match(match_request={'query': track_embedding, 'num_recos': (size + 1)})
-        recos_response = self.response_builder_factory.get_builder(status_code=HTTPStatus.OK.value).build_response(recos_response=recos[0], id=id, size=int(size))
+        recos_response = self.response_builder_factory.get_builder(status_code=HTTPStatus.OK.value).build_response(recos_response=recos[0], track_id=id, size=int(size))
         
         return recos_response
     

--- a/src/api/util/reco/reco_controller.py
+++ b/src/api/util/reco/reco_controller.py
@@ -20,10 +20,10 @@ class V1RecoController(RecoController):
             recos_response = self._reco_adapter.get_recos(id, size)
         except HTTPError as http_error:
             print(http_error.__str__())
-            recos_response = self._response_builder_factory.get_builder(status_code=http_error.code).build_response(recos_response=None, id=id, size=size)
+            recos_response = self._response_builder_factory.get_builder(status_code=http_error.code).build_response(recos_response=None, track_id=id, size=size)
         except ClientHTTPError as client_http_error:
             print(client_http_error.__str__())
-            recos_response = self._response_builder_factory.get_builder(status_code=client_http_error.response.status_code).build_response(recos_response=None, id=id, size=size)
+            recos_response = self._response_builder_factory.get_builder(status_code=client_http_error.response.status_code).build_response(recos_response=None, track_id=id, size=size)
         
         return recos_response
 

--- a/test/unit_tests/api/schemas/test_response.py
+++ b/test/unit_tests/api/schemas/test_response.py
@@ -47,7 +47,7 @@ class ResponseFactoryTestSuite(unittest.TestCase):
 
 class ResponseBuilderTestSuite(unittest.TestCase):
     def test_should_properly_build_400_response(self):
-        bad_request_response = response.BadRequestResponseBuilder().build_response(recos_response={}, id='123', size=5)
+        bad_request_response = response.BadRequestResponseBuilder().build_response(recos_response={}, track_id='123', size=5)
         response_400 = {
             "message": "Bad request.",
             "status": 400
@@ -57,7 +57,7 @@ class ResponseBuilderTestSuite(unittest.TestCase):
         self.assertEqual(400, bad_request_response.response_code)
     
     def test_should_properly_build_401_response(self):
-        unauthorized_response = response.UnauthorizedResponseBuilder().build_response(recos_response={}, id='123', size=5)
+        unauthorized_response = response.UnauthorizedResponseBuilder().build_response(recos_response={}, track_id='123', size=5)
         response_401 = {
             'message': 'Valid authentication credentials not provided.',
             'status': 401
@@ -67,7 +67,7 @@ class ResponseBuilderTestSuite(unittest.TestCase):
         self.assertEqual(401, unauthorized_response.response_code)
     
     def test_should_properly_build_403_response(self):
-        forbidden_response = response.ForbiddenResponseBuilder().build_response(recos_response={}, id='123', size=5)
+        forbidden_response = response.ForbiddenResponseBuilder().build_response(recos_response={}, track_id='123', size=5)
         response_403 = {
             'message': 'Insufficient authentication credentials.',
             'status': 403
@@ -77,7 +77,7 @@ class ResponseBuilderTestSuite(unittest.TestCase):
         self.assertEqual(403, forbidden_response.response_code)
     
     def test_should_properly_build_404_response(self):
-        not_found_response = response.NotFoundResponseBuilder().build_response(recos_response={}, id='123', size=5)
+        not_found_response = response.NotFoundResponseBuilder().build_response(recos_response={}, track_id='123', size=5)
         response_404 = {
             "message": "Invalid track id: 123",
             "status": 404
@@ -87,7 +87,7 @@ class ResponseBuilderTestSuite(unittest.TestCase):
         self.assertEqual(404, not_found_response.response_code)
     
     def test_should_properly_build_500_response(self):
-        internal_server_error_response = response.InternalServerErrorResponseBuilder().build_response(recos_response={}, id='123', size=5)
+        internal_server_error_response = response.InternalServerErrorResponseBuilder().build_response(recos_response={}, track_id='123', size=5)
         response_500 = {
             'message': 'An unexpected error occurred. Please contact a contributor for assistance.',
             'status': 500
@@ -118,7 +118,7 @@ class ResponseBuilderTestSuite(unittest.TestCase):
                 }
             }
         }
-        ok_response = response.OkResponseBuilder().build_response(recos_response=recos, id='123', size=2)
+        ok_response = response.OkResponseBuilder().build_response(recos_response=recos, track_id='123', size=2)
 
         self.assertEqual(expected_response, ok_response.response)
         self.assertEqual(200, ok_response.response_code)
@@ -145,13 +145,14 @@ class ResponseBuilderTestSuite(unittest.TestCase):
                 }
             }
         }
-        ok_response = response.OkResponseBuilder().build_response(recos_response=recos, id='123', size=2)
+        ok_response = response.OkResponseBuilder().build_response(recos_response=recos, track_id='123', size=2)
 
         self.assertEqual(expected_response, ok_response.response)
         self.assertEqual(200, ok_response.response_code)
     
     def test_should_properly_build_201_response(self):
-        created_response = response.CreatedResponseBuilder().build_response(recos_response={}, id='123', size=5)
+        created_response = response.CreatedResponseBuilder().build_response(recos_response={}, track_id='123', size=5, playlist_id='playlist_id')
 
         self.assertEqual({}, created_response.response)
         self.assertEqual(201, created_response.response_code)
+        self.assertEqual('https://api.spotify.com/v1/playlists/playlist_id', created_response.response_headers.get('Location', type=str))

--- a/test/unit_tests/api/schemas/test_response.py
+++ b/test/unit_tests/api/schemas/test_response.py
@@ -6,14 +6,20 @@ from google.cloud.aiplatform.matching_engine.matching_engine_index_endpoint impo
 class ResponseFactoryTestSuite(unittest.TestCase):
     def setUp(self) -> None:
         self._bad_request_response_builder = response.BadRequestResponseBuilder()
+        self._unauthorized_response_builder = response.UnauthorizedResponseBuilder()
+        self._forbidden_response_builder = response.ForbiddenResponseBuilder()
         self._not_found_response_builder = response.NotFoundResponseBuilder()
         self._internal_server_error_builder = response.InternalServerErrorResponseBuilder()
         self._ok_response_builder = response.OkResponseBuilder()
+        self._created_response_builder = response.CreatedResponseBuilder()
         self._response_builder_factory = response.ResponseBuilderFactory(
-            self._bad_request_response_builder,
-            self._not_found_response_builder,
-            self._internal_server_error_builder,
-            self._ok_response_builder
+            bad_request_builder=self._bad_request_response_builder,
+            unauthorized_builder=self._unauthorized_response_builder,
+            forbidden_builder=self._forbidden_response_builder,
+            not_found_builder=self._not_found_response_builder,
+            internal_server_error_builder=self._internal_server_error_builder,
+            ok_builder=self._ok_response_builder,
+            created_builder=self._created_response_builder
         )
     
     def test_should_return_bad_request_response_builder_on_400(self):
@@ -49,6 +55,26 @@ class ResponseBuilderTestSuite(unittest.TestCase):
 
         self.assertEqual(response_400, bad_request_response.response)
         self.assertEqual(400, bad_request_response.response_code)
+    
+    def test_should_properly_build_401_response(self):
+        unauthorized_response = response.UnauthorizedResponseBuilder().build_response(recos_response={}, id='123', size=5)
+        response_401 = {
+            'message': 'Valid authentication credentials not provided.',
+            'status': 401
+        }
+
+        self.assertEqual(response_401, unauthorized_response.response)
+        self.assertEqual(401, unauthorized_response.response_code)
+    
+    def test_should_properly_build_403_response(self):
+        forbidden_response = response.ForbiddenResponseBuilder().build_response(recos_response={}, id='123', size=5)
+        response_403 = {
+            'message': 'Insufficient authentication credentials.',
+            'status': 403
+        }
+
+        self.assertEqual(response_403, forbidden_response.response)
+        self.assertEqual(403, forbidden_response.response_code)
     
     def test_should_properly_build_404_response(self):
         not_found_response = response.NotFoundResponseBuilder().build_response(recos_response={}, id='123', size=5)
@@ -123,3 +149,9 @@ class ResponseBuilderTestSuite(unittest.TestCase):
 
         self.assertEqual(expected_response, ok_response.response)
         self.assertEqual(200, ok_response.response_code)
+    
+    def test_should_properly_build_201_response(self):
+        created_response = response.CreatedResponseBuilder().build_response(recos_response={}, id='123', size=5)
+
+        self.assertEqual({}, created_response.response)
+        self.assertEqual(201, created_response.response_code)


### PR DESCRIPTION
## Related Issue
- #122 
<!-- Related issues go here -->

## Description
- The strategy for response handling for all APIs introduced in #29 does not include support for response headers. Since the contract changes proposed in #93 for the `POST::/v1/playlist/{id*}` API require the [Location](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Location) response header (to indicate the absolute URI of the newly created playlist resource), this pull request is created in order to refactor the response handling logic to also accommodate any necessary response headers.
  - In order to refactor this strategy, we amended the existing interface in a backwards-compatible fashion to allow for optional [response headers](https://werkzeug.palletsprojects.com/en/2.2.x/datastructures/#werkzeug.datastructures.Headers). By doing so, response headers can be added as a list of tuples containing key-value pairs for necessary response headers, i.e.:
```
return Response(response={}, response_code=self._response_code, response_headers=
[
    ('Content-Type', 'application/json'),
    ('Location', 'https://api.spotify.com/v1/playlists/6SPT5Y24sS4H2U3e0PPXoW')
])
```
  - Since the contract proposed in #93 allows for the 201 (Created), 401 (Unauthorized), and 403 (Forbidden) status codes, cdcfb8bbbe1ad585d05acbddd034ade54d3727df is included in this pull request to handle response building for each of these cases.
<!-- Brief but accurate description for issues and solution proposed -->

## Tests Included
- [X] Unit tests
- [ ]  Integration tests
- [ ] Environment tests
- [X] Regression tests
- [ ] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
<img width="1680" alt="Screen Shot 2023-01-28 at 10 07 27 PM" src="https://user-images.githubusercontent.com/10148029/215308352-b08e004b-5ff9-41f5-9b59-56f69d4418c4.png">
