### PR TITLE
Add code coverage phase to CI pipeline

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -35,7 +35,7 @@ jobs:
       - run: pip install -r requirements.txt
       - run: coverage run --source=src/api/ -m unittest discover test/unit_tests/
       - run: coverage xml
-      - uses: ogoro/coverage@v3
+      - uses: orgoro/coverage@v3
         with:
           coverageFile: ./coverage.xml
           token: ${{ github.token }}

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -20,6 +20,25 @@ jobs:
         # Could not find any documentation on mocking google cloud client libraries for unit tests. We mock credentials as an alternative.
         env:
           GOOGLE_APPLICATION_CREDENTIALS: test/unit_tests/mock_secret.json
+  code_coverage:
+    name: Unit test coverage
+    runs-on: ubuntu-latest
+    needs: unit_tests
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+          architecture: 'x64'
+          token: ${{ github.token }}
+      - run: pip install -r requirements.txt
+      - run: coverage run --source=src/api/ -m unittest discover test/unit_tests/
+      - run: coverage xml
+      - uses: ogoro/coverage@v3
+        with:
+          coverageFile: ./coverage.xml
+          token: ${{ github.token }}
   lint_check:
     name: Pylint check
     runs-on: ubuntu-latest
@@ -33,5 +52,4 @@ jobs:
           architecture: 'x64'
           token: ${{ github.token }}
       - run: pip install -r requirements.txt
-      - name: Python Linter
-        run: python -m pylint src/ test/ --rcfile=.pylintrc --ignore-paths=src/api/third_party/
+      - run: python -m pylint src/ test/ --rcfile=.pylintrc --ignore-paths=src/api/third_party/

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -39,6 +39,8 @@ jobs:
         with:
           coverageFile: ./coverage.xml
           token: ${{ github.token }}
+          thresholdAll: 0.8
+          thresholdNew: 0.8
   lint_check:
     name: Pylint check
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 **.pyc
 **/__pycache__
 **/venv
+.coverage
+coverage.xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ cachetools==5.2.0
 certifi==2022.6.15
 charset-normalizer==2.1.0
 click==8.1.3
+coverage==7.1.0
 dill==0.3.6
 flasgger==0.9.5
 Flask==2.2.2


### PR DESCRIPTION
## Related Issue
<!-- Related issues go here -->
- #133 

## Description
- Our current CI pipeline should include a code coverage phase in order to verify a sufficient amount of unit testing is maintained for this project. This pull request is created in order to add a code coverage phase with [codecoveragepy](https://github.com/nedbat/coveragepy) and [Python Coverage](https://github.com/marketplace/actions/python-coverage).
  - As a baseline for code coverage, changes from 6614400 will fail CI jobs with a unit test coverage of less than 80%.
<!-- Brief but accurate description for issues and solution proposed -->

## Tests Included
- [ ] Unit tests
- [ ]  Integration tests
- [ ] Environment tests
- [ ] Regression tests
- [ ] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
