### PR TITLE
Added integration tests for 4xx use cases on `POST::/v1/users/{user_id}/playlists` API

### DIFF
--- a/test/integration_tests/api/clients/spotify_client/test_client.py
+++ b/test/integration_tests/api/clients/spotify_client/test_client.py
@@ -83,3 +83,11 @@ class SpotifyClientTestSuite(unittest.TestCase):
     self.assertRaises(exceptions.HTTPError,
                       self.spotify_client.v1_audio_features,
                       '62BGM9bNkNcvOh13B4wOyr')
+
+  def test_should_raise_error_for_invalid_bearer_token_on_v1_create_playlist(
+      self) -> None:
+    pass
+
+  def test_should_raise_error_for_insufficient_bearer_token_scope_on_v1_create_playlist(
+      self) -> None:
+    pass

--- a/test/integration_tests/api/clients/spotify_client/test_client.py
+++ b/test/integration_tests/api/clients/spotify_client/test_client.py
@@ -29,35 +29,36 @@ class SpotifyClientTestSuite(unittest.TestCase):
     with flask_app.app_context():
       config_facade = ConfigFacade()
       auth_client = SpotifyAuthClient(config_facade=config_facade)
-      self.spotify_client = SpotifyClient(auth_client=auth_client,
-                                          logging_client=logging_client,
-                                          config_facade=config_facade)
+      self._spotify_client = SpotifyClient(auth_client=auth_client,
+                                           logging_client=logging_client,
+                                           config_facade=config_facade)
+      self._auth_client = auth_client
 
   def test_should_return_response_for_valid_track_id_on_v1_tracks(self) -> None:
-    response = self.spotify_client.v1_tracks('62BGM9bNkNcvOh13B4wOyr')
+    response = self._spotify_client.v1_tracks('62BGM9bNkNcvOh13B4wOyr')
     self.assertIsNotNone(response)
 
   # pylint: disable-next=line-too-long
   def test_should_return_response_for_valid_track_id_and_marketplace_on_v1_tracks(
       self) -> None:
-    response = self.spotify_client.v1_tracks('62BGM9bNkNcvOh13B4wOyr',
-                                             marketplace='US')
+    response = self._spotify_client.v1_tracks('62BGM9bNkNcvOh13B4wOyr',
+                                              marketplace='US')
     self.assertIsNotNone(response)
 
   def test_should_raise_error_for_invalid_track_id_on_v1_tracks(self) -> None:
-    self.assertRaises(exceptions.HTTPError, self.spotify_client.v1_tracks,
+    self.assertRaises(exceptions.HTTPError, self._spotify_client.v1_tracks,
                       'invalid_track_id')
 
   def test_should_raise_error_for_invalid_bearer_token_on_v1_tracks(
       self) -> None:
-    self.spotify_client.get_bearer_token = Mock(
+    self._spotify_client.get_bearer_token = Mock(
         return_value='invalid_bearer_token')
-    self.assertRaises(exceptions.HTTPError, self.spotify_client.v1_tracks,
+    self.assertRaises(exceptions.HTTPError, self._spotify_client.v1_tracks,
                       '62BGM9bNkNcvOh13B4wOyr')
 
   def test_should_return_response_for_valid_track_id_on_v1_audio_features(
       self) -> None:
-    response = self.spotify_client.v1_audio_features('62BGM9bNkNcvOh13B4wOyr')
+    response = self._spotify_client.v1_audio_features('62BGM9bNkNcvOh13B4wOyr')
     self.assertIsNotNone(response)
     self.assertIsNotNone(response['danceability'])
     self.assertIsNotNone(response['energy'])
@@ -74,20 +75,28 @@ class SpotifyClientTestSuite(unittest.TestCase):
   def test_should_raise_error_for_invalid_track_id_on_v1_audio_features(
       self) -> None:
     self.assertRaises(exceptions.HTTPError,
-                      self.spotify_client.v1_audio_features, 'invalid_track_id')
+                      self._spotify_client.v1_audio_features,
+                      'invalid_track_id')
 
   def test_should_raise_error_for_invalid_bearer_token_on_v1_audio_features(
       self) -> None:
-    self.spotify_client.get_bearer_token = Mock(
+    self._spotify_client.get_bearer_token = Mock(
         return_value='invalid_bearer_token')
     self.assertRaises(exceptions.HTTPError,
-                      self.spotify_client.v1_audio_features,
+                      self._spotify_client.v1_audio_features,
                       '62BGM9bNkNcvOh13B4wOyr')
 
   def test_should_raise_error_for_invalid_bearer_token_on_v1_create_playlist(
       self) -> None:
-    pass
+    self.assertRaises(exceptions.HTTPError,
+                      self._spotify_client.v1_create_playlist, 'noahteshima',
+                      'invalid_token')
 
-  def test_should_raise_error_for_insufficient_bearer_token_scope_on_v1_create_playlist(
+  def test_should_raise_error_for_wrong_token_scope_on_v1_create_playlist(
       self) -> None:
-    pass
+    # public, read-only scope - will cause 403 due to insufficient permission
+    token = self._auth_client.get_bearer_token()
+    token = f'Bearer {token}'
+    self.assertRaises(exceptions.HTTPError,
+                      self._spotify_client.v1_create_playlist, 'noahteshima',
+                      token)


### PR DESCRIPTION
## Related Issue
- #130 

## Description
- It was mentioned on #106 that integration tests cannot be added to the `POST::/v1/users/{user_id}/playlists` API client due to the scope of authorization needed: since client credentials flow for Spotify's APIs only allows for Bearer tokens with read-only access to public resources, testing the 200 use case is difficult to do in the integration test suites. However, 4xx use cases (401, 403) can still be tested, since this just requires using an invalid token (401) and a token with insufficient scope (403). This pull request introduces integration tests for the 4xx use cases on the `POST::/v1/users/{user_id}/playlists` API.
  - Note that based on the [documentation](https://developer.spotify.com/documentation/web-api/reference/#/operations/create-playlist), 429 status code for rate limiting is also supported. We decided to not test this one since this use case is only reachable in the integration test suite if the 200 use case is reachable as well.

## Tests Included
- [ ] Unit tests
- [X]  Integration tests
- [ ] Environment tests
- [X] Regression tests
- [ ] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
<img width="1680" alt="Screen Shot 2023-02-12 at 5 24 18 PM" src="https://user-images.githubusercontent.com/10148029/218351086-bdeeddeb-7b4d-4b4b-98fb-77df2de7f921.png">
