### PR TITLE
Integration tests for 4xx use cases on `POST::/v1/playlists/{playlist_id}/tracks` API client

### DIFF
--- a/test/integration_tests/api/clients/spotify_client/test_client.py
+++ b/test/integration_tests/api/clients/spotify_client/test_client.py
@@ -103,8 +103,18 @@ class SpotifyClientTestSuite(unittest.TestCase):
 
   def test_should_raise_error_for_invalid_bearer_token_on_v1_playlist_tracks(
       self) -> None:
-    pass
+    self.assertRaises(exceptions.HTTPError,
+                      self._spotify_client.v1_playlist_tracks,
+                      '1Wy3exSZouKDmDGQYIDuHT',
+                      {'uris': ['spotify:track:62xX1yYJ283Qni51S4SP5d']},
+                      'invalid_token')
 
   def test_should_raise_error_for_wrong_token_scope_on_v1_playlist_tracks(
       self) -> None:
-    pass
+    # public, read-only scope - will cause 403 due to insufficient permission
+    token = self._auth_client.get_bearer_token()
+    token = f'Bearer {token}'
+    self.assertRaises(exceptions.HTTPError,
+                      self._spotify_client.v1_playlist_tracks,
+                      '1Wy3exSZouKDmDGQYIDuHT',
+                      {'uris': ['spotify:track:62xX1yYJ283Qni51S4SP5d']}, token)

--- a/test/integration_tests/api/clients/spotify_client/test_client.py
+++ b/test/integration_tests/api/clients/spotify_client/test_client.py
@@ -100,3 +100,11 @@ class SpotifyClientTestSuite(unittest.TestCase):
     self.assertRaises(exceptions.HTTPError,
                       self._spotify_client.v1_create_playlist, 'noahteshima',
                       token)
+
+  def test_should_raise_error_for_invalid_bearer_token_on_v1_playlist_tracks(
+      self) -> None:
+    pass
+
+  def test_should_raise_error_for_wrong_token_scope_on_v1_playlist_tracks(
+      self) -> None:
+    pass


### PR DESCRIPTION
## Related Issue
- #129

## Description
- It was mentioned on #108 that integration tests cannot be added to the `POST::/v1/playlists/{playlist_id}/tracks` API client due to the scope of authorization needed: since client credentials flow for Spotify's APIs only allows for Bearer tokens with read-only access to public resources, testing the 200 use case is difficult to do in the integration test suites. However, 4xx use cases (401, 403) can still be tested, since this just requires using an invalid token (401) and a token with insufficient scope (403). This pull request introduces integration tests for the 4xx use cases on the `POST::/v1/playlists/{playlist_id}/tracks` API.
  - This pull request adopts very similar changes to #137 due to the similarity for both API contracts.

## Tests Included
- [ ] Unit tests
- [X]  Integration tests
- [ ] Environment tests
- [X] Regression tests
- [ ] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
<img width="1680" alt="Screen Shot 2023-02-12 at 7 30 12 PM" src="https://user-images.githubusercontent.com/10148029/218364354-38b76ef9-bc62-4108-87fc-27f936296ca7.png">
