### PR TITLE
Add Gunicorn WSGI server for service deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM python:3.8-slim-buster
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 COPY requirements.txt requirements.txt
-COPY src/ src/
+COPY src/api/ src/api/
 
 RUN pip3 install -r requirements.txt
 
-CMD ["python3", "-m", "flask", "run", "--host=0.0.0.0"]
+CMD ["gunicorn", "--workers=1", "src.api.app:flask_app", "--bind=127.0.0.1:5000"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ COPY src/api/ src/api/
 
 RUN pip3 install -r requirements.txt
 
-CMD ["gunicorn", "--workers=1", "src.api.app:flask_app", "--bind=127.0.0.1:5000"]
+CMD ["gunicorn", "--workers=1", "src.api.app:flask_app", "--bind=0.0.0.0:5000"]
 

--- a/deployment.yml
+++ b/deployment.yml
@@ -32,7 +32,7 @@ spec:
         imagePullPolicy: Always
         resources:
           limits:
-            memory: 192Mi
+            memory: 160Mi
             cpu: 75m
           requests:
             memory: 128Mi

--- a/deployment.yml
+++ b/deployment.yml
@@ -63,7 +63,7 @@ spec:
         - name: SECRET_VERSION_ID
           value: "latest"
         - name: ENVIRONMENT
-          value: "development"
+          value: "staging"
         - name: FLASK_APP
           value: "/app/src/api/app"
       # Sidecar container for warmups. We take this example directly from the expedia group documentation

--- a/deployment.yml
+++ b/deployment.yml
@@ -32,10 +32,10 @@ spec:
         imagePullPolicy: Always
         resources:
           limits:
-            memory: 128Mi
+            memory: 192Mi
             cpu: 75m
           requests:
-            memory: 64Mi
+            memory: 128Mi
             cpu: 50m
         ports:
         - containerPort: 5000

--- a/deployment.yml
+++ b/deployment.yml
@@ -63,7 +63,7 @@ spec:
         - name: SECRET_VERSION_ID
           value: "latest"
         - name: ENVIRONMENT
-          value: "staging"
+          value: "development"
         - name: FLASK_APP
           value: "/app/src/api/app"
       # Sidecar container for warmups. We take this example directly from the expedia group documentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ grpc-google-iam-v1==0.12.4
 grpcio==1.47.0
 grpcio-status==1.47.0
 grpcio-tools==1.47.0
+gunicorn==20.1.0
 idna==3.3
 importlib-metadata==4.12.0
 isort==5.12.0


### PR DESCRIPTION
## Related Issue
<!-- Related issues go here -->
- #140 

## Description
- Based on the [Flask documentation](https://flask.palletsprojects.com/en/2.2.x/deploying/) for exposing service deployments publicly, we should look into a WSGI server that is intended to be used beyond development. This pull request is created in order to add [Gunicorn](https://docs.gunicorn.org/en/stable/) as the chosen WSGI server for our GKE deployments.
  - Gunicorn was the chosen WSGI server. Based on the documentation, a non-blocking model with [async workers](https://docs.gunicorn.org/en/stable/design.html?highlight=async#async-workers) can be easily configured. Our web service is IO-bound, due to the amount of work that we perform over a network for this service and the limited amount of CPU resourcing needed to respond to clients. Being able to configure async workers with Gunicorn will allow us to handle a greater number of concurrent requests.
  - Beyond WSGI server configuration, e9cb8cd3df9c20de24272c98dcc37cd02fc6cc74 and 732cbaaec4816d3a246b083c0c63d4f66cc2de61 introduce vertical scaling changes for our deployment; since new python packages were included in da0e69e6eae8cb099be8b82e1dffc832011f31a0 to accommodate Gunicorn, [additional memory was allocated to pods](https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource/#specify-a-memory-request-and-a-memory-limit) to prevent containers from getting OOMKilled.
  - In order to test these changes, smoke tests were done on a GKE cluster to verify the stability of the changes introduced. The screenshots below show a sample request after integrating Gunicorn as the chosen WSGI server for staging deployments.
<!-- Brief but accurate description for issues and solution proposed -->

## Tests Included
- [ ] Unit tests
- [ ]  Integration tests
- [ ] Environment tests
- [ ] Regression tests
- [X] Smoke tests

## Screenshots
<img width="1680" alt="Screen Shot 2023-02-18 at 4 10 30 PM" src="https://user-images.githubusercontent.com/10148029/219905129-15bd4284-8cf4-4d8c-a52f-6e7f95e77980.png">
<img width="1680" alt="Screen Shot 2023-02-18 at 4 04 17 PM" src="https://user-images.githubusercontent.com/10148029/219905134-196b5c1e-78f3-439c-8266-1d89bb7bd56f.png">

<!-- Optional if screenshots provide clarity/context -->
