### PR TITLE
Add integration tests for 4xx status code use cases on `POST::/v1/playlist/{user_id*}/{track_id*}` API

### DIFF
--- a/src/api/routes/playlist.py
+++ b/src/api/routes/playlist.py
@@ -17,9 +17,14 @@ def v1_playlist_user_id_track_id(user_id: str, track_id: str):
   response = None
   try:
     size = request.args.get(key='size') or str(5)
-    user_token = request.headers['Authorization']
-    response = reco_util.v1_reco_controller.create_playlist(
-        user_id=user_id, track_id=track_id, user_token=user_token, size=size)
+    if not 'Authorization' in request.headers:
+      response = schemas.response_builder_factory.get_builder(
+          status_code=HTTPStatus.BAD_REQUEST.value).build_response(
+              recos_response=None, track_id=track_id, size=size)
+    else:
+      user_token = request.headers['Authorization']
+      response = reco_util.v1_reco_controller.create_playlist(
+          user_id=user_id, track_id=track_id, user_token=user_token, size=size)
   except Exception:  # pylint: disable=broad-exception-caught
     print(traceback.format_exc())
     response = schemas.response_builder_factory.get_builder(

--- a/src/api/routes/playlist.py
+++ b/src/api/routes/playlist.py
@@ -36,6 +36,7 @@ def v1_playlist_user_id_track_id(user_id: str, track_id: str):
 
   flask_response = Response(response=response.response,
                             status=response.response_code,
-                            headers=response.response_headers)
+                            headers=response.response_headers,
+                            content_type='application/json')
 
   return flask_response

--- a/src/api/routes/playlist.py
+++ b/src/api/routes/playlist.py
@@ -34,7 +34,7 @@ def v1_playlist_user_id_track_id(user_id: str, track_id: str):
     print(json.dumps(response.response))
     print(response.response_code)
 
-  flask_response = Response(response=response.response,
+  flask_response = Response(response=json.dumps(response.response),
                             status=response.response_code,
                             headers=response.response_headers,
                             content_type='application/json')

--- a/src/api/routes/playlist.py
+++ b/src/api/routes/playlist.py
@@ -14,11 +14,10 @@ playlist = Blueprint('playlist', __name__)
 
 @playlist.route('/<user_id>/<track_id>', methods=['POST'])
 def v1_playlist_user_id_track_id(user_id: str, track_id: str):
-  size = request.args.get(key='size') or str(5)
-  user_token = request.headers['Authorization']
-
   response = None
   try:
+    size = request.args.get(key='size') or str(5)
+    user_token = request.headers['Authorization']
     response = reco_util.v1_reco_controller.create_playlist(
         user_id=user_id, track_id=track_id, user_token=user_token, size=size)
   except Exception:  # pylint: disable=broad-exception-caught

--- a/test/integration_tests/routes/test_playlist_id.py
+++ b/test/integration_tests/routes/test_playlist_id.py
@@ -10,7 +10,7 @@ class PlaylistResourceTestSuite(unittest.TestCase):
   def setUp(self) -> None:
     self._spotifind_client = flask_app.test_client()
     self._spotify_auth_client = spotify_auth_client
-    self._user_id = 'nteshima'
+    self._user_id = 'noahteshima'
     self._track_id = '6AUlMVr80H8KGVTGeJlpbp'
     self._uri = f'/v1/playlist/{self._user_id}/{self._track_id}'
 

--- a/test/integration_tests/routes/test_playlist_id.py
+++ b/test/integration_tests/routes/test_playlist_id.py
@@ -24,7 +24,7 @@ class PlaylistResourceTestSuite(unittest.TestCase):
         'message': 'Valid authentication credentials not provided.',
         'status': 401
     }
-    headers = {'Authorization': 'Invalid token'}
+    headers = [('Authorization', 'Invalid token')]
 
     response = self._spotifind_client.post(self._uri, headers=headers)
     response_json = response.json
@@ -38,7 +38,7 @@ class PlaylistResourceTestSuite(unittest.TestCase):
         'status': 403
     }
     token_bearer = self._spotify_auth_client.get_bearer_token()
-    headers = {'Authorization': f'Bearer {token_bearer}'}
+    headers = [('Authorization', f'Bearer {token_bearer}')]
 
     response = self._spotifind_client.post(self._uri, headers=headers)
     response_json = response.json

--- a/test/integration_tests/routes/test_playlist_id.py
+++ b/test/integration_tests/routes/test_playlist_id.py
@@ -6,7 +6,10 @@ from werkzeug.datastructures import Headers
 
 
 class PlaylistResourceTestSuite(unittest.TestCase):
-  """ Integration test suite for POST::v1/{user_id}/{track_id} API. """
+  """
+  Integration test suite for POST::v1/{user_id}/{track_id} API.
+  Due to the scope of authorization needed for the 201 use case, we only test the 4xx use cases here.
+  """
 
   def setUp(self) -> None:
     self._spotifind_client = flask_app.test_client()
@@ -16,8 +19,13 @@ class PlaylistResourceTestSuite(unittest.TestCase):
     self._uri = f'/v1/playlist/{self._user_id}/{self._track_id}'
 
   def test_should_return_400_for_invalid_size(self) -> None:
-    response = self._spotifind_client.post(f'{self._uri}?size=0')
+    response_400 = {'message': 'Bad request.', 'status': 400}
 
+    response = self._spotifind_client.post(f'{self._uri}?size=0')
+    response_json = response.json
+
+    self.assertIsNotNone(response_json)
+    self.assertEqual(response_400, response_json)
     self.assertEqual(400, response.status_code)
 
   def test_should_return_401_for_invalid_authorization_header(self) -> None:
@@ -33,6 +41,7 @@ class PlaylistResourceTestSuite(unittest.TestCase):
 
     self.assertIsNotNone(response_json)
     self.assertEqual(response_401, response_json)
+    self.assertEqual(401, response.status_code)
 
   def test_should_return_403_for_insufficient_authorization_scope(self) -> None:
     response_403 = {
@@ -49,3 +58,4 @@ class PlaylistResourceTestSuite(unittest.TestCase):
 
     self.assertIsNotNone(response_json)
     self.assertEqual(response_403, response_json)
+    self.assertEqual(403, response.status_code)

--- a/test/integration_tests/routes/test_playlist_id.py
+++ b/test/integration_tests/routes/test_playlist_id.py
@@ -20,16 +20,28 @@ class PlaylistResourceTestSuite(unittest.TestCase):
     self.assertEqual(400, response.status_code)
 
   def test_should_return_401_for_invalid_authorization_header(self) -> None:
+    response_401 = {
+        'message': 'Valid authentication credentials not provided.',
+        'status': 401
+    }
     headers = {'Authorization': 'Invalid token'}
 
     response = self._spotifind_client.post(self._uri, headers=headers)
+    response_json = response.json
 
-    self.assertEqual(401, response.status_code)
+    self.assertIsNotNone(response_json)
+    self.assertEqual(response_401, response_json)
 
   def test_should_return_403_for_insufficient_authorization_scope(self) -> None:
+    response_403 = {
+        'message': 'Insufficient authentication credentials.',
+        'status': 403
+    }
     token_bearer = self._spotify_auth_client.get_bearer_token()
     headers = {'Authorization': f'Bearer {token_bearer}'}
 
     response = self._spotifind_client.post(self._uri, headers=headers)
+    response_json = response.json
 
-    self.assertEqual(403, response.status_code)
+    self.assertIsNotNone(response_json)
+    self.assertEqual(response_403, response_json)

--- a/test/integration_tests/routes/test_playlist_id.py
+++ b/test/integration_tests/routes/test_playlist_id.py
@@ -26,7 +26,7 @@ class PlaylistResourceTestSuite(unittest.TestCase):
         'status': 401
     }
     headers = Headers()
-    headers.add('Authorization', 'Invalid token')
+    headers.add('Authorization', 'Bearer invalid_token')
 
     response = self._spotifind_client.post(self._uri, headers=headers)
     response_json = response.json

--- a/test/integration_tests/routes/test_playlist_id.py
+++ b/test/integration_tests/routes/test_playlist_id.py
@@ -1,23 +1,35 @@
 """ Integration test module for playlist resources. """
 import unittest
 from src.api.app import flask_app
-from werkzeug.test import TestResponse
+from src.api.clients.spotify_auth_client import spotify_auth_client
 
 
 class PlaylistResourceTestSuite(unittest.TestCase):
   """ Integration test suite for POST::v1/{user_id}/{track_id} API. """
 
   def setUp(self) -> None:
-    self._client = flask_app.test_client()
+    self._spotifind_client = flask_app.test_client()
+    self._spotify_auth_client = spotify_auth_client
     self._user_id = 'nteshima'
     self._track_id = '6AUlMVr80H8KGVTGeJlpbp'
     self._uri = f'/v1/playlist/{self._user_id}/{self._track_id}'
 
   def test_should_return_400_for_invalid_size(self) -> None:
-    pass
+    response = self._spotifind_client.post(f'{self._uri}?size=0')
+
+    self.assertEqual(400, response.status_code)
 
   def test_should_return_401_for_invalid_authorization_header(self) -> None:
-    pass
+    headers = {'Authorization': 'Invalid token'}
+
+    response = self._spotifind_client.post(self._uri, headers=headers)
+
+    self.assertEqual(401, response.status_code)
 
   def test_should_return_403_for_insufficient_authorization_scope(self) -> None:
-    pass
+    token_bearer = self._spotify_auth_client.get_bearer_token()
+    headers = {'Authorization': f'Bearer {token_bearer}'}
+
+    response = self._spotifind_client.post(self._uri, headers=headers)
+
+    self.assertEqual(403, response.status_code)

--- a/test/integration_tests/routes/test_playlist_id.py
+++ b/test/integration_tests/routes/test_playlist_id.py
@@ -7,8 +7,9 @@ from werkzeug.datastructures import Headers
 
 class PlaylistResourceTestSuite(unittest.TestCase):
   """
-  Integration test suite for POST::v1/{user_id}/{track_id} API.
-  Due to the scope of authorization needed for the 201 use case, we only test the 4xx use cases here.
+    Integration test suite for POST::v1/{user_id}/{track_id} API.
+    Due to the scope of authorization needed for the 201 use case,
+    we only test the 4xx use cases here.
   """
 
   def setUp(self) -> None:

--- a/test/integration_tests/routes/test_playlist_id.py
+++ b/test/integration_tests/routes/test_playlist_id.py
@@ -1,0 +1,23 @@
+""" Integration test module for playlist resources. """
+import unittest
+from src.api.app import flask_app
+from werkzeug.test import TestResponse
+
+
+class PlaylistResourceTestSuite(unittest.TestCase):
+  """ Integration test suite for POST::v1/{user_id}/{track_id} API. """
+
+  def setUp(self) -> None:
+    self._client = flask_app.test_client()
+    self._user_id = 'nteshima'
+    self._track_id = '6AUlMVr80H8KGVTGeJlpbp'
+    self._uri = f'/v1/playlist/{self._user_id}/{self._track_id}'
+
+  def test_should_return_400_for_invalid_size(self) -> None:
+    pass
+
+  def test_should_return_401_for_invalid_authorization_header(self) -> None:
+    pass
+
+  def test_should_return_403_for_insufficient_authorization_scope(self) -> None:
+    pass

--- a/test/integration_tests/routes/test_playlist_id.py
+++ b/test/integration_tests/routes/test_playlist_id.py
@@ -2,6 +2,7 @@
 import unittest
 from src.api.app import flask_app
 from src.api.clients.spotify_auth_client import spotify_auth_client
+from werkzeug.datastructures import Headers
 
 
 class PlaylistResourceTestSuite(unittest.TestCase):
@@ -24,7 +25,8 @@ class PlaylistResourceTestSuite(unittest.TestCase):
         'message': 'Valid authentication credentials not provided.',
         'status': 401
     }
-    headers = [('Authorization', 'Invalid token')]
+    headers = Headers()
+    headers.add('Authorization', 'Invalid token')
 
     response = self._spotifind_client.post(self._uri, headers=headers)
     response_json = response.json
@@ -38,7 +40,9 @@ class PlaylistResourceTestSuite(unittest.TestCase):
         'status': 403
     }
     token_bearer = self._spotify_auth_client.get_bearer_token()
-    headers = [('Authorization', f'Bearer {token_bearer}')]
+    token_bearer = token_bearer['access_token']
+    headers = Headers()
+    headers.add('Authorization', f'Bearer {token_bearer}')
 
     response = self._spotifind_client.post(self._uri, headers=headers)
     response_json = response.json


### PR DESCRIPTION
## Related Issue
<!-- Related issues go here -->
- #139

## Description
- Integration tests cannot be added for the 201 use case for the ``POST::/v1/playlist/{user_id*}/{track_id*}`` API due to the scope of authorization needed. However, we should still focus on adding integration tests for some of the non-200 cases for this API (400, 401, 403). This pull request is created to add integration tests for all of these cases.
  - The integration test suite for each case (400 Bad Request, 401 Forbidden, 403 Unauthorized) was introduced in 03e492506a1ba10a6478d8827b314b6869b7d184. The following changes were done in order to test each case:
    - For the 400 (Bad Request) use case, API call to `POST::/v1/playlist/{user_id*}/{track_id*}` will fail if the `size` query parameter is incorrectly used. For this case, we should return a 400 status code if `POST::/v1/playlist/{user_id*}/{track_id*}?size=0` is used.
    - For the 401 (Forbidden) use case, downstream service call to Spotify [create playlist API](https://developer.spotify.com/console/post-playlists/) will fail if an invalid Bearer token is used. For this case, the `Authorization` header is passed with a value of `Bearer invalid_token`.
    - For the 403 (Unauthorized) use case, downstream service call to Spotify [create playlist API](https://developer.spotify.com/console/post-playlists/) will fail if a Bearer token of insufficient scope is used. For this use case, we pass a _valid_ Bearer token with only read-only access to public resources.
<!-- Brief but accurate description for issues and solution proposed -->

## Tests Included
- [ ] Unit tests
- [X]  Integration tests
- [ ] Environment tests
- [X] Regression tests
- [ ] Smoke tests

## Screenshots
<img width="1680" alt="Screen Shot 2023-02-20 at 4 11 53 PM" src="https://user-images.githubusercontent.com/10148029/220216012-a583b604-5fd5-487c-8e7d-c7a85c1c0c93.png">
<!-- Optional if screenshots provide clarity/context -->
