### PR TITLE
Add integration tests for Spotify `GET::v1/tracks` bulk API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,17 +67,17 @@ Spotifind API is exposed behind two endpoints. Note that HTTPS is the required p
 #### GET::/v1/reco/{id*}
 Get recommendations for Spotify track URIs based on an input track URI.
 
-| Resource  | Description | Type | Path parameters | Query parameters |
-| ------------- | ------------- | ------------- | ------------- | ------------- |
-| /v1/reco/{id*}  | Retrieve Spotify tracks to recommend based on the given track id | GET | **id** - Spotify Track ID to use when getting recommendations | **size** - Number of recommendations to return. Default size 5
+| Resource       | Description                                                      | Type | Path parameters                                               | Query parameters                                               |
+| -------------- | ---------------------------------------------------------------- | ---- | ------------------------------------------------------------- | -------------------------------------------------------------- |
+| /v1/reco/{id*} | Retrieve Spotify tracks to recommend based on the given track id | GET  | **id** - Spotify Track ID to use when getting recommendations | **size** - Number of recommendations to return. Default size 5 |
 
 ##### HTTP response status codes
-| Status code | Description |
-| ------------- | ------------- |
-| 200  | When track id recommendations are returned successfully |
-| 400  | Miscellaneous client failure |
-| 404  | Client failure due to invalid track id |
-| 500  | Miscellaneous service failure |
+| Status code | Description                                             |
+| ----------- | ------------------------------------------------------- |
+| 200         | When track id recommendations are returned successfully |
+| 400         | Miscellaneous client failure                            |
+| 404         | Client failure due to invalid track id                  |
+| 500         | Miscellaneous service failure                           |
 
 ##### Example Usage
 **Request**
@@ -160,29 +160,29 @@ HTTPS/1.1 404 NOT FOUND
 #### POST::/v1/playlist/{user_id*}/{track_id*}
 Create a Spotify playlist containing recommended Spotify track URIs based on an input track URI for a target user.
 
-| Resource  | Description | Type | Path parameters | Query parameters |
-| ------------- | ------------- | ------------- | ------------- | ------------- |
-| /v1/playlist/{id*}  | Create Spotify playlist with recommended tracks based on the given track id | POST | **user_id** - Spotify user ID to generate the playlist for (i.e. noahteshima) <br> **track_id** - Spotify track ID to use when generating playlist | **size** - Size of the playlist to generate. Default size 5
+| Resource           | Description                                                                 | Type | Path parameters                                                                                                                                    | Query parameters                                            |
+| ------------------ | --------------------------------------------------------------------------- | ---- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| /v1/playlist/{id*} | Create Spotify playlist with recommended tracks based on the given track id | POST | **user_id** - Spotify user ID to generate the playlist for (i.e. noahteshima) <br> **track_id** - Spotify track ID to use when generating playlist | **size** - Size of the playlist to generate. Default size 5 |
 
 ##### HTTP response status codes
-| Status code | Description |
-| ------------- | ------------- |
-| 201  | When Spotify playlist is created successfully |
-| 400  | Miscellaneous client failure |
-| 401  | Client failure due to missing `Authorization` header |
-| 403  | Client failure due to insufficient scopes in `Authorization` header |
-| 404  | Client failure due to invalid track id |
-| 500  | Miscellaneous service failure |
+| Status code | Description                                                         |
+| ----------- | ------------------------------------------------------------------- |
+| 201         | When Spotify playlist is created successfully                       |
+| 400         | Miscellaneous client failure                                        |
+| 401         | Client failure due to missing `Authorization` header                |
+| 403         | Client failure due to insufficient scopes in `Authorization` header |
+| 404         | Client failure due to invalid track id                              |
+| 500         | Miscellaneous service failure                                       |
 
 ##### Request headers
-| Request header | Value(s) |
-| ------------- | ------------- |
+| Request header | Value(s)                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Authorization  | Bearer {token}, where `token` is a Bearer token from [Spotify](https://developer.spotify.com/documentation/general/guides/authorization/scopes/) with [playlist-modify-public](https://developer.spotify.com/documentation/general/guides/authorization/scopes/#playlist-modify-public), [playlist-modify-private](https://developer.spotify.com/documentation/general/guides/authorization/scopes/#playlist-modify-private) scopes |
 
 ##### Response headers
-| Response header | Value(s) |
-| ------------- | ------------- |
-| Location  | https://api.spotify.com/v1/playlists/{playlist_id}, where `playlist_id` is the newly created playlist |
+| Response header | Value(s)                                                                                              |
+| --------------- | ----------------------------------------------------------------------------------------------------- |
+| Location        | https://api.spotify.com/v1/playlists/{playlist_id}, where `playlist_id` is the newly created playlist |
 
 ##### Example Usage
 **Request**
@@ -338,5 +338,16 @@ python -m unittest discover test/unit_tests/
 #### Integration testing
 
 Integration tests currently run on the CD, but it is suggested to run integrations tests prior to this to avoid having to revert breaking changes. Since the ANN index service is currently deployed behind a Virtual Private Cloud, all integration tests currently need to be run on a cluster in Google Cloud. To run integration tests, a Kubernetes cluster on [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine) can be provisioned. From Google Cloud Build, the *GKE-Continuous-Deployment* pipeline can be copied and changed to run on a separate branch. After making these changes, commits added to the remote (this) repository will trigger a new CD pipeline run in Google Cloud.
+
+Most integration test suites can still be run locally (excluding those that include gRPC calls to matching service). This can sometimes be useful to avoid having to "debug on the CI/CD" or to reduce the feedback loop for properly testing changes. In order to run integration tests locally, the following changes should be done:
+1. This service uses [google-auth](https://google-auth.readthedocs.io/en/master/user-guide.html) to authenticate into services on Google Cloud. On your local environment, first create [default application credentials](https://cloud.google.com/docs/authentication/application-default-credentials) for development. It is recommended to create these application credentials by submitting your [user credentials](https://cloud.google.com/docs/authentication/application-default-credentials#personal) with gcloud and exporting the location of these locations with an environment variable. For these steps, we exported the location of the default application credentials to an environment variable `GOOGLE_APPLICATION_CREDENTIALS`
+2. Once these credentials are available in your local environment, run the following docker command from the base directory of this project to create a Dockerfile for running integration tests:
+```
+docker build -t integration-tests:latest -f ./tests/integration_tests/Dockerfile .
+```
+3. Once the image for running integration tests is built, mount your application credentials when running the image with the following command:
+```
+docker run -v $GOOGLE_APPLICATION_CREDENTIALS:/tmp/keys/credentials.json:ro -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/keys/credentials.json integration-tests:latest
+```
 
 

--- a/test/integration_tests/Dockerfile
+++ b/test/integration_tests/Dockerfile
@@ -15,4 +15,4 @@ ENV SECRET_ID="spotify-rest-api-secret"
 ENV SECRET_VERSION_ID="latest"
 ENV ENVIRONMENT="staging"
 
-CMD [ "python3", "-m", "unittest", "discover", "-s", "./test/integration_tests/" ]
+CMD [ "python3", "-m", "unittest", "discover", "-s", "./test/integration_tests/", "--verbose" ]

--- a/test/integration_tests/api/clients/spotify_client/test_client.py
+++ b/test/integration_tests/api/clients/spotify_client/test_client.py
@@ -58,23 +58,65 @@ class SpotifyClientTestSuite(unittest.TestCase):
 
   def test_should_return_response_for_single_valid_track_id_on_v1_tracks_bulk(
       self) -> None:
-    pass
+    track_ids = ['7vQzm9id9OADh4tigOfaHo']
+    response = self._spotify_client.v1_tracks_bulk(track_ids=track_ids)
+
+    self.assertIsNotNone(response)
+
+    response_tracks = response['tracks']
+    self.assertEqual(1, len(response_tracks))
+
+    response_track1 = response_tracks[0]
+    self.assertIsNotNone(response_track1)
+    self.assertEqual('7vQzm9id9OADh4tigOfaHo', response_track1['id'])
 
   def test_should_return_response_for_multiple_valid_track_id_on_v1_tracks_bulk(
       self) -> None:
-    pass
+    track_ids = ['7vQzm9id9OADh4tigOfaHo', '0u9B86E4rLW88UXn6FPMyu']
+    response = self._spotify_client.v1_tracks_bulk(track_ids=track_ids)
+
+    self.assertIsNotNone(response)
+
+    response_tracks = response['tracks']
+    self.assertEqual(2, len(response_tracks))
+
+    response_track1 = response_tracks[0]
+    self.assertIsNotNone(response_track1)
+    self.assertEqual('7vQzm9id9OADh4tigOfaHo', response_track1['id'])
+
+    response_track2 = response_tracks[1]
+    self.assertIsNotNone(response_track2)
+    self.assertEqual('0u9B86E4rLW88UXn6FPMyu', response_track2['id'])
 
   def test_should_raise_error_for_invalid_bearer_token_on_v1_tracks_bulk(
       self) -> None:
-    pass
+    self._spotify_client.get_bearer_token = Mock(
+        return_value='Bearer invalid_token')
+    track_ids = ['7vQzm9id9OADh4tigOfaHo']
+
+    self.assertRaises(exceptions.HTTPError, self._spotify_client.v1_tracks_bulk,
+                      track_ids)
 
   def test_should_return_null_for_invalid_track_ids_on_v1_tracks_bulk(
       self) -> None:
-    pass
+    track_ids = ['invalidTrackId']
+
+    response = self._spotify_client.v1_tracks_bulk(track_ids=track_ids)
+
+    self.assertIsNotNone(response)
+
+    response_tracks = response['tracks']
+    self.assertEqual(1, len(response_tracks))
+
+    response_track1 = response_tracks[0]
+    self.assertIsNone(response_track1)
 
   def test_should_raise_error_for_missing_track_ids_param_on_v1_tracks_bulk(
       self) -> None:
-    pass
+    track_ids = []
+
+    self.assertRaises(exceptions.HTTPError, self._spotify_client.v1_tracks_bulk,
+                      track_ids)
 
   def test_should_return_response_for_valid_track_id_on_v1_audio_features(
       self) -> None:

--- a/test/integration_tests/api/clients/spotify_client/test_client.py
+++ b/test/integration_tests/api/clients/spotify_client/test_client.py
@@ -118,6 +118,15 @@ class SpotifyClientTestSuite(unittest.TestCase):
     self.assertRaises(exceptions.HTTPError, self._spotify_client.v1_tracks_bulk,
                       track_ids)
 
+  def test_should_raise_error_for_too_many_track_ids_on_v1_tracks_bulk(
+      self) -> None:
+    # Threshold for bulk API call quantity is 50 track IDs. 51 track IDs or more
+    # should yield a 4xx response.
+    track_ids = ['7vQzm9id9OADh4tigOfaHo'] * 51
+
+    self.assertRaises(exceptions.HTTPError, self._spotify_client.v1_tracks_bulk,
+                      track_ids)
+
   def test_should_return_response_for_valid_track_id_on_v1_audio_features(
       self) -> None:
     response = self._spotify_client.v1_audio_features('62BGM9bNkNcvOh13B4wOyr')

--- a/test/integration_tests/api/clients/spotify_client/test_client.py
+++ b/test/integration_tests/api/clients/spotify_client/test_client.py
@@ -56,6 +56,26 @@ class SpotifyClientTestSuite(unittest.TestCase):
     self.assertRaises(exceptions.HTTPError, self._spotify_client.v1_tracks,
                       '62BGM9bNkNcvOh13B4wOyr')
 
+  def test_should_return_response_for_single_valid_track_id_on_v1_tracks_bulk(
+      self) -> None:
+    pass
+
+  def test_should_return_response_for_multiple_valid_track_id_on_v1_tracks_bulk(
+      self) -> None:
+    pass
+
+  def test_should_raise_error_for_invalid_bearer_token_on_v1_tracks_bulk(
+      self) -> None:
+    pass
+
+  def test_should_return_null_for_invalid_track_ids_on_v1_tracks_bulk(
+      self) -> None:
+    pass
+
+  def test_should_raise_error_for_missing_track_ids_param_on_v1_tracks_bulk(
+      self) -> None:
+    pass
+
   def test_should_return_response_for_valid_track_id_on_v1_audio_features(
       self) -> None:
     response = self._spotify_client.v1_audio_features('62BGM9bNkNcvOh13B4wOyr')


### PR DESCRIPTION
## Related Issue
- #150 
<!-- Related issues go here -->

## Description
- Following #148, we are primarily interested in adding integration tests for the Spotify `GET::v1/tracks` bulk API client before making implementation changes to support the `verbose={true|false}` query parameter. This pull request is created to amend the existing Spotify REST client integration test suite to include test cases for the new API client.
  - Test cases for this API client were added in 7dc5a0b6e92044f4897ff098ff9dec9632c5ad63. These test cases are based on the contract included for the `GET::v1/tracks` bulk API [documentation](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-several-tracks).
  - In order to verify these changes, the integration tests for the Spotify REST API client suite were ran locally and remotely with Cloud Build. The screenshot below shows a successful job run with all integration tests. 
  - In the past, we had the tendency to debug integration tests remotely based on the results from Cloud Build. This creates a large feedback loop in comparison to running the integration tests directly in our local environment. To mitigate this, 656f4a70a7274b8834d3cec019ce27078a69feff introduces documentation for running most of the integration test suites in a local environment.
<!-- Brief but accurate description for issues and solution proposed -->

## Tests Included
- [ ] Unit tests
- [X]  Integration tests
- [x] Environment tests
- [X] Regression tests
- [ ] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
<img width="1680" alt="Screen Shot 2023-03-25 at 3 34 40 PM" src="https://user-images.githubusercontent.com/10148029/227745616-f47f1b2f-4e27-411f-b755-f3261a600d92.png">
