### PR TITLE
Add CORS policy configuration to all APIs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ coverage==7.1.0
 dill==0.3.6
 flasgger==0.9.5
 Flask==2.2.2
+Flask-Cors==3.0.10
 google-api-core==2.8.2
 google-auth==2.9.0
 google-cloud==0.34.0

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,5 +1,6 @@
 """ Module for creating application instance and Blueprints for routing. """
 from flask import Flask, Blueprint
+from flask_cors import CORS
 from .routes.healthcheck import healthcheck
 from src.api.routes import reco, playlist, healthcheck
 from src.api.config import config
@@ -35,6 +36,7 @@ def load_blueprints(app: Flask) -> None:
 
 flask_app = Flask(__name__)
 flask_app.app_context().push()
+CORS(flask_app)
 
 load_xff_proxy_configuration(flask_app)
 load_blueprints(flask_app)


### PR DESCRIPTION
## Related Issue
- #156 
<!-- Related issues go here -->

## Description
- In order to integrate with calling clients, we are primarily interested in configuring a [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) policy for all APIs. This pull request is created in order to configure a CORS policy for all existing APIs.
  - In order to add our CORS policy, we added an integration with the [Flask-CORS](https://flask-cors.readthedocs.io/en/latest/) module. To test these changes, smoke tests were done on a local Kubernetes cluster with the existing APIs. Below is an example request for the `GET::/v1/reco/{id*}` API with the `Access-Control-Allow-Origin` response header. It uses a wildcard value since we decided to allow access across all origins.

## Tests Included
- [ ] Unit tests
- [ ]  Integration tests
- [X] Environment tests
- [ ] Regression tests
- [X] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
<img width="1192" alt="Screen Shot 2023-04-30 at 9 20 43 PM" src="https://user-images.githubusercontent.com/10148029/235854183-310e9989-ec69-4d63-959c-c3b790efa0a7.png">
